### PR TITLE
chore: allowed empty default for modules

### DIFF
--- a/aws-region/main.test.ts
+++ b/aws-region/main.test.ts
@@ -13,7 +13,7 @@ describe("aws-region", async () => {
 
   it("default output", async () => {
     const state = await runTerraformApply(import.meta.dir, {});
-    expect(state.outputs.value.value).toBe("us-east-1");
+    expect(state.outputs.value.value).toBe("");
   });
 
   it("customized default", async () => {

--- a/aws-region/main.tf
+++ b/aws-region/main.tf
@@ -22,7 +22,6 @@ variable "description" {
 }
 
 variable "default" {
-  default     = "us-east-1"
   description = "The default region to use if no region is specified."
   type        = string
 }
@@ -131,7 +130,7 @@ data "coder_parameter" "region" {
   name         = "aws_region"
   display_name = var.display_name
   description  = var.description
-  default      = var.default
+  default      = var.default == "" ? null : var.default
   mutable      = var.mutable
   dynamic "option" {
     for_each = { for k, v in local.regions : k => v if !(contains(var.exclude, k)) }

--- a/aws-region/main.tf
+++ b/aws-region/main.tf
@@ -22,6 +22,7 @@ variable "description" {
 }
 
 variable "default" {
+  default     = ""
   description = "The default region to use if no region is specified."
   type        = string
 }

--- a/azure-region/main.test.ts
+++ b/azure-region/main.test.ts
@@ -13,7 +13,7 @@ describe("azure-region", async () => {
 
   it("default output", async () => {
     const state = await runTerraformApply(import.meta.dir, {});
-    expect(state.outputs.value.value).toBe("eastus");
+    expect(state.outputs.value.value).toBe("");
   });
 
   it("customized default", async () => {

--- a/azure-region/main.tf
+++ b/azure-region/main.tf
@@ -308,7 +308,7 @@ data "coder_parameter" "region" {
   name         = "azure_region"
   display_name = var.display_name
   description  = var.description
-  default      = var.default == "" ? null : var.default
+  default      = null # var.default == "" ? null : var.default
   mutable      = var.mutable
   dynamic "option" {
     for_each = { for k, v in local.all_regions : k => v if !(contains(var.exclude, k)) }

--- a/azure-region/main.tf
+++ b/azure-region/main.tf
@@ -318,11 +318,6 @@ data "coder_parameter" "region" {
       value = option.key
     }
   }
-  validation {
-    # Functions as an error message for when the coder parameter is not selected
-    regex = "^(?!\\s*$).+"
-    error = "Azure region must be selected."
-  }
 }
 
 output "value" {

--- a/azure-region/main.tf
+++ b/azure-region/main.tf
@@ -308,7 +308,7 @@ data "coder_parameter" "region" {
   name         = "azure_region"
   display_name = var.display_name
   description  = var.description
-  default      = null # var.default == "" ? null : var.default
+  default      = var.default == "" ? null : var.default
   mutable      = var.mutable
   dynamic "option" {
     for_each = { for k, v in local.all_regions : k => v if !(contains(var.exclude, k)) }
@@ -317,6 +317,10 @@ data "coder_parameter" "region" {
       icon  = try(var.custom_icons[option.key], option.value.icon)
       value = option.key
     }
+  }
+  validation {
+    regex = "^.+$"
+    error = "Azure region must be selected."
   }
 }
 

--- a/azure-region/main.tf
+++ b/azure-region/main.tf
@@ -319,7 +319,8 @@ data "coder_parameter" "region" {
     }
   }
   validation {
-    regex = "^.+$"
+    # Functions as an error message for when the coder parameter is not selected
+    regex = "^(?!\\s*$).+"
     error = "Azure region must be selected."
   }
 }

--- a/azure-region/main.tf
+++ b/azure-region/main.tf
@@ -21,7 +21,7 @@ variable "description" {
 }
 
 variable "default" {
-  default = ""
+  default     = ""
   description = "The default region to use if no region is specified."
   type        = string
 }

--- a/azure-region/main.tf
+++ b/azure-region/main.tf
@@ -308,7 +308,7 @@ data "coder_parameter" "region" {
   name         = "azure_region"
   display_name = var.display_name
   description  = var.description
-  default      = var.default
+  default      = var.default == "" ? null : var.default
   mutable      = var.mutable
   dynamic "option" {
     for_each = { for k, v in local.all_regions : k => v if !(contains(var.exclude, k)) }

--- a/azure-region/main.tf
+++ b/azure-region/main.tf
@@ -21,7 +21,7 @@ variable "description" {
 }
 
 variable "default" {
-  default     = "eastus"
+  default = ""
   description = "The default region to use if no region is specified."
   type        = string
 }

--- a/jetbrains-gateway/README.md
+++ b/jetbrains-gateway/README.md
@@ -13,11 +13,11 @@ This module adds a JetBrains Gateway Button to open any workspace with a single 
 
 ```hcl
 module "jetbrains_gateway" {
-  source                   = "https://registry.coder.com/modules/jetbrains-gateway"
-  agent_id                 = coder_agent.example.id
-  agent_name               = "example"
-  project_directory        = "/home/coder/example"
-  jetbrains_ides           = ["GO", "WS", "IU", "IC", "PY", "PC", "PS", "CL", "RM", "DB", "RD"]
+  source         = "https://registry.coder.com/modules/jetbrains-gateway"
+  agent_id       = coder_agent.example.id
+  agent_name     = "example"
+  folder         = "/home/coder/example"
+  jetbrains_ides = ["GO", "WS", "IU", "IC", "PY", "PC", "PS", "CL", "RM", "DB", "RD"]
 }
 ```
 
@@ -29,12 +29,12 @@ module "jetbrains_gateway" {
 
 ```hcl
 module "jetbrains_gateway" {
-  source                   = "https://registry.coder.com/modules/jetbrains-gateway"
-  agent_id                 = coder_agent.example.id
-  agent_name               = "example"
-  project_directory        = "/home/coder/example"
-  jetbrains_ides           = ["GO", "WS"]
-  default                  = "GO"
+  source          = "https://registry.coder.com/modules/jetbrains-gateway"
+  agent_id        = coder_agent.example.id
+  agent_name      = "example"
+  folder          = "/home/coder/example"
+  jetbrains_ides  = ["GO", "WS"]
+  default         = "GO"
 }
 ```
 

--- a/jetbrains-gateway/main.test.ts
+++ b/jetbrains-gateway/main.test.ts
@@ -1,7 +1,5 @@
-import { describe, expect, it } from "bun:test";
+import { describe } from "bun:test";
 import {
-  executeScriptInContainer,
-  runTerraformApply,
   runTerraformInit,
   testRequiredVariables,
 } from "../test";
@@ -12,7 +10,7 @@ describe("jetbrains-gateway`", async () => {
   await testRequiredVariables(import.meta.dir, {
     agent_id: "foo",
     agent_name: "bar",
-    project_directory: "/baz/",
+    folder: "/baz/",
     jetbrains_ides: '["IU", "IC", "PY"]',
   });
 });

--- a/jetbrains-gateway/main.test.ts
+++ b/jetbrains-gateway/main.test.ts
@@ -10,9 +10,9 @@ describe("jetbrains-gateway`", async () => {
   await runTerraformInit(import.meta.dir);
 
   await testRequiredVariables(import.meta.dir, {
-    agent_id:  "foo",
+    agent_id: "foo",
     agent_name: "bar",
     project_directory: "/baz/",
-    jetbrains_ides: "[\"IU\", \"IC\", \"PY\"]",
+    jetbrains_ides: '["IU", "IC", "PY"]',
   });
 });

--- a/jetbrains-gateway/main.test.ts
+++ b/jetbrains-gateway/main.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import {
+  executeScriptInContainer,
+  runTerraformApply,
+  runTerraformInit,
+  testRequiredVariables,
+} from "../test";
+
+describe("jetbrains-gateway`", async () => {
+  await runTerraformInit(import.meta.dir);
+
+  await testRequiredVariables(import.meta.dir, {
+    agent_id:  "foo",
+    agent_name: "bar",
+    project_directory: "/baz/",
+    jetbrains_ides: "[\"IU\", \"IC\", \"PY\"]",
+  });
+});

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -19,7 +19,7 @@ variable "agent_name" {
   description = "The name of a Coder agent."
 }
 
-variable "project_directory" {
+variable "folder" {
   type        = string
   description = "The directory to open in the IDE. e.g. /home/coder/project"
 }
@@ -146,7 +146,7 @@ resource "coder_app" "gateway" {
     "&agent=",
     var.agent_name,
     "&folder=",
-    var.project_directory,
+    var.folder,
     "&url=",
     data.coder_workspace.me.access_url,
     "&token=",

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -25,7 +25,7 @@ variable "project_directory" {
 }
 
 variable "default" {
-  default     = null
+  default     = ""
   type        = string
   description = "Default IDE"
 }
@@ -120,7 +120,7 @@ data "coder_parameter" "jetbrains_ide" {
   icon         = "/icon/gateway.svg"
   mutable      = true
   # check if default is in the jet_brains_ides list and if it is not empty or null otherwise set it to null
-  default = var.default != null && var.default != "" && contains(var.jetbrains_ides, var.default) ? local.jetbrains_ides[var.default].value : null
+  default = var.default != null && var.default != "" && contains(var.jetbrains_ides, var.default) ? local.jetbrains_ides[var.default].value : local.jetbrains_ides[var.jetbrains_ides[0]].value
 
   dynamic "option" {
     for_each = { for key, value in local.jetbrains_ides : key => value if contains(var.jetbrains_ides, key) }
@@ -156,7 +156,7 @@ resource "coder_app" "gateway" {
     "&ide_build_number=",
     jsondecode(data.coder_parameter.jetbrains_ide.value)[1],
     "&ide_download_link=",
-    jsondecode(data.coder_parameter.jetbrains_ide.value)[2]
+    jsondecode(data.coder_parameter.jetbrains_ide.value)[2],
   ])
 }
 

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -46,7 +46,7 @@ variable "jetbrains_ides" {
     condition     = length(var.jetbrains_ides) > 0
     error_message = "The jetbrains_ides must not be empty."
   }
-  #ccheck if the list contains duplicates
+  # check if the list contains duplicates
   validation {
     condition     = length(var.jetbrains_ides) == length(toset(var.jetbrains_ides))
     error_message = "The jetbrains_ides must not contain duplicates."


### PR DESCRIPTION
From #66, also added testing for `jetbrains-gateway`.

## Regions
Azure and AWS were simple, but there is no error message when no region is selected:

https://github.com/coder/modules/assets/58410745/9a9e317b-7764-427f-b298-86313de5fb33

Open to feedback on this.

## Jetbrains Gateway
The Jetbrains gateway default IDE satisfies a ton of logic in the template, so allowing `null` would lead to a lot of patchwork `try` statements. Now it's implemented to use the first IDE in the `jetbrains_ides` as the coder_parameter default for cleanliness. 

Let me know your thoughts.