### PR TITLE
add missing tests

### DIFF
--- a/code-server/main.test.ts
+++ b/code-server/main.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import {
-  executeScriptInContainer,
-  runTerraformApply,
-  runTerraformInit,
-  testRequiredVariables,
-} from "../test";
+import { runTerraformInit, testRequiredVariables } from "../test";
 
 describe("code-server", async () => {
   await runTerraformInit(import.meta.dir);
@@ -12,4 +7,6 @@ describe("code-server", async () => {
   testRequiredVariables(import.meta.dir, {
     agent_id: "foo",
   });
+
+  // More tests depend on shebang refactors
 });

--- a/code-server/main.test.ts
+++ b/code-server/main.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import {
+  executeScriptInContainer,
+  runTerraformApply,
+  runTerraformInit,
+  testRequiredVariables,
+} from "../test";
+
+describe("code-server", async () => {
+  await runTerraformInit(import.meta.dir);
+
+  testRequiredVariables(import.meta.dir, {
+    agent_id: "foo",
+  });
+});

--- a/coder-login/main.tf
+++ b/coder-login/main.tf
@@ -23,7 +23,7 @@ resource "coder_script" "coder-login" {
     CODER_DEPLOYMENT_URL : data.coder_workspace.me.access_url
   })
   display_name       = "Coder Login"
-  icon               = "http://svgur.com/i/y5G.svg"
+  icon               = "/icon/coder.svg"
   run_on_start       = true
   start_blocks_login = true
 }

--- a/dotfiles/main.test.ts
+++ b/dotfiles/main.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import {
+  runTerraformApply,
+  runTerraformInit,
+  testRequiredVariables,
+} from "../test";
+
+describe("dotfiles", async () => {
+  await runTerraformInit(import.meta.dir);
+
+  testRequiredVariables(import.meta.dir, {
+    agent_id: "foo",
+  });
+
+});

--- a/dotfiles/main.test.ts
+++ b/dotfiles/main.test.ts
@@ -12,4 +12,10 @@ describe("dotfiles", async () => {
     agent_id: "foo",
   });
 
+  it("default output", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+    });
+    expect(state.outputs.dotfiles_uri.value).toBe("");
+  });
 });

--- a/fly-region/main.test.ts
+++ b/fly-region/main.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "bun:test";
 import {
-  executeScriptInContainer,
   runTerraformApply,
   runTerraformInit,
   testRequiredVariables,

--- a/fly-region/main.test.ts
+++ b/fly-region/main.test.ts
@@ -22,4 +22,12 @@ describe("fly-region", async () => {
     });
     expect(state.outputs.value.value).toBe("atl");
   });
+
+  it("region filter", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      default: "atl",
+      regions: '["arn", "ams", "bos"]'
+    });
+    expect(state.outputs.value.value).toBe("");
+  });
 });

--- a/fly-region/main.test.ts
+++ b/fly-region/main.test.ts
@@ -25,7 +25,7 @@ describe("fly-region", async () => {
   it("region filter", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       default: "atl",
-      regions: '["arn", "ams", "bos"]'
+      regions: '["arn", "ams", "bos"]',
     });
     expect(state.outputs.value.value).toBe("");
   });

--- a/gcp-region/README.md
+++ b/gcp-region/README.md
@@ -28,6 +28,8 @@ resource "google_compute_instance" "example" {
 
 ### Add only GPU zones in the US West 1 region
 
+Note: setting `gpu_only = true` and using a default region without GPU support, the default will be set to `null`.
+
 ```hcl
 module "gcp_region" {
     source   = "https://registry.coder.com/modules/gcp-region"

--- a/gcp-region/main.test.ts
+++ b/gcp-region/main.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "bun:test";
 import {
-  executeScriptInContainer,
   runTerraformApply,
   runTerraformInit,
   testRequiredVariables,

--- a/gcp-region/main.test.ts
+++ b/gcp-region/main.test.ts
@@ -23,4 +23,22 @@ describe("gcp-region", async () => {
     });
     expect(state.outputs.value.value).toBe("asia-east1-a");
   });
+
+  it("gpu only invalid default", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      regions: '["us-west2"]',
+      default: "us-west2-a",
+      gpu_only: "true",
+    });
+    expect(state.outputs.value.value).toBe("");
+  });
+
+  it("gpu only valid default", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      regions: '["us-west2"]',
+      default: "us-west2-b",
+      gpu_only: "true",
+    });
+    expect(state.outputs.value.value).toBe("us-west2-b");
+  });
 });

--- a/gcp-region/main.test.ts
+++ b/gcp-region/main.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import {
+  executeScriptInContainer,
+  runTerraformApply,
+  runTerraformInit,
+  testRequiredVariables,
+} from "../test";
+
+describe("gcp-region", async () => {
+  await runTerraformInit(import.meta.dir);
+
+  testRequiredVariables(import.meta.dir, {});
+
+  it("default output", async () => {
+    const state = await runTerraformApply(import.meta.dir, {});
+    expect(state.outputs.value.value).toBe("");
+  });
+
+  it("customized default", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      regions: '["asia"]',
+      default: "asia-east1-a",
+    });
+    expect(state.outputs.value.value).toBe("asia-east1-a");
+  });
+});

--- a/gcp-region/main.tf
+++ b/gcp-region/main.tf
@@ -714,7 +714,7 @@ data "coder_parameter" "region" {
   description  = var.description
   icon         = "/icon/gcp.png"
   mutable      = var.mutable
-  default      = var.default != null && var.default != "" ? var.default : null
+  default      = var.default != null && var.default != "" && (!var.gpu_only || try(local.zones[var.default].gpu, false)) ? var.default : null
   dynamic "option" {
     for_each = {
       for k, v in local.zones : k => v

--- a/jetbrains-gateway/main.test.ts
+++ b/jetbrains-gateway/main.test.ts
@@ -1,5 +1,10 @@
-import { describe } from "bun:test";
-import { runTerraformInit, testRequiredVariables } from "../test";
+import { it, expect, describe } from "bun:test";
+import {
+  runTerraformInit,
+  testRequiredVariables,
+  executeScriptInContainer,
+  runTerraformApply,
+} from "../test";
 
 describe("jetbrains-gateway", async () => {
   await runTerraformInit(import.meta.dir);
@@ -9,5 +14,17 @@ describe("jetbrains-gateway", async () => {
     agent_name: "bar",
     folder: "/baz/",
     jetbrains_ides: '["IU", "IC", "PY"]',
+  });
+
+  it("default to first ide", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      agent_name: "bar",
+      folder: "/baz/",
+      jetbrains_ides: '["IU", "IC", "PY"]',
+    });
+    expect(state.outputs.jetbrains_ides.value).toBe(
+      '["IU","232.9921.47","https://download.jetbrains.com/idea/ideaIU-2023.2.2.tar.gz"]',
+    );
   });
 });

--- a/jetbrains-gateway/main.test.ts
+++ b/jetbrains-gateway/main.test.ts
@@ -1,7 +1,7 @@
 import { describe } from "bun:test";
 import { runTerraformInit, testRequiredVariables } from "../test";
 
-describe("jetbrains-gateway`", async () => {
+describe("jetbrains-gateway", async () => {
   await runTerraformInit(import.meta.dir);
 
   await testRequiredVariables(import.meta.dir, {

--- a/jupyterlab/main.test.ts
+++ b/jupyterlab/main.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import {
+  executeScriptInContainer,
+  runTerraformApply,
+  runTerraformInit,
+  testRequiredVariables,
+  findResourceInstance,
+  runContainer,
+} from "../test";
+
+const executeScriptInContainer = async (
+  state: TerraformState,
+  image: string,
+  shell: string = "sh",
+): Promise<{
+  exitCode: number;
+  stdout: string[];
+  stderr: string[];
+}> => {
+  const instance = findResourceInstance(state, "coder_script");
+  const id = await runContainer(image);
+  const resp = await execContainer(id, [shell, "-c", instance.script]);
+  const stdout = resp.stdout.trim().split("\n");
+  const stderr = resp.stderr.trim().split("\n");
+  return {
+    exitCode: resp.exitCode,
+    stdout,
+    stderr,
+  };
+};
+
+describe("jupyterlab", async () => {
+  await runTerraformInit(import.meta.dir);
+
+  testRequiredVariables(import.meta.dir, {
+    agent_id: "foo",
+  });
+
+  it("fails without pip3", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+    });
+
+    const instance = findResourceInstance(state, "coder_script");
+    const id = await runContainer("alpine");
+    const output = await executeScriptInContainer(state, "alpine");
+    expect(output.exitCode).toBe(1);
+    expect(output.stdout).toEqual([
+      "\u001B[0;1mInstalling jupyterlab!",
+      "pip3 is not installed",
+      "Please install pip3 in your Dockerfile/VM image before running this script",
+    ]);
+  });
+
+  // TODO: Add test that runs with pip
+  // May be best to use dockerfile
+});

--- a/jupyterlab/main.test.ts
+++ b/jupyterlab/main.test.ts
@@ -10,7 +10,6 @@ import {
   execContainer,
 } from "../test";
 
-
 // executes the coder script after installing pip
 const executeScriptInContainerWithPip = async (
   state: TerraformState,
@@ -23,7 +22,7 @@ const executeScriptInContainerWithPip = async (
 }> => {
   const instance = findResourceInstance(state, "coder_script");
   const id = await runContainer(image);
-  const respPip = await execContainer(id, [shell, "-c", "apk add py3-pip"]);  
+  const respPip = await execContainer(id, [shell, "-c", "apk add py3-pip"]);
   const resp = await execContainer(id, [shell, "-c", instance.script]);
   const stdout = resp.stdout.trim().split("\n");
   const stderr = resp.stderr.trim().split("\n");
@@ -54,12 +53,11 @@ describe("jupyterlab", async () => {
     ]);
   });
 
-  // TODO: Add faster test to run with pip3. 
+  // TODO: Add faster test to run with pip3.
   // currently times out.
   // it("runs with pip3", async () => {
   //   ...
   //   const output = await executeScriptInContainerWithPip(state, "alpine");
   //   ...
   // });
-
 });

--- a/jupyterlab/main.test.ts
+++ b/jupyterlab/main.test.ts
@@ -6,9 +6,13 @@ import {
   testRequiredVariables,
   findResourceInstance,
   runContainer,
+  TerraformState,
+  execContainer,
 } from "../test";
 
-const executeScriptInContainer = async (
+
+// executes the coder script after installing pip
+const executeScriptInContainerWithPip = async (
   state: TerraformState,
   image: string,
   shell: string = "sh",
@@ -19,6 +23,7 @@ const executeScriptInContainer = async (
 }> => {
   const instance = findResourceInstance(state, "coder_script");
   const id = await runContainer(image);
+  const respPip = await execContainer(id, [shell, "-c", "apk add py3-pip"]);  
   const resp = await execContainer(id, [shell, "-c", instance.script]);
   const stdout = resp.stdout.trim().split("\n");
   const stderr = resp.stderr.trim().split("\n");
@@ -40,9 +45,6 @@ describe("jupyterlab", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",
     });
-
-    const instance = findResourceInstance(state, "coder_script");
-    const id = await runContainer("alpine");
     const output = await executeScriptInContainer(state, "alpine");
     expect(output.exitCode).toBe(1);
     expect(output.stdout).toEqual([
@@ -52,6 +54,12 @@ describe("jupyterlab", async () => {
     ]);
   });
 
-  // TODO: Add test that runs with pip
-  // May be best to use dockerfile
+  // TODO: Add faster test to run with pip3. 
+  // currently times out.
+  // it("runs with pip3", async () => {
+  //   ...
+  //   const output = await executeScriptInContainerWithPip(state, "alpine");
+  //   ...
+  // });
+
 });

--- a/personalize/main.test.ts
+++ b/personalize/main.test.ts
@@ -31,35 +31,4 @@ describe("personalize", async () => {
     ]);
   });
 
-  // it("runs with personalize script", async () => {
-  //   const state = await runTerraformApply(import.meta.dir, {
-  //     agent_id: "foo",
-  //   });
-  //   const instance = findResourceInstance(state, "coder_script");
-  //   const id = await runContainer("alpine");
-  //   const respInit = await execContainer(id, [
-  //     "sh",
-  //     "-c",
-  //     'touch ~/personalize && echo "echo test" > ~/personalize && chmod +x ~/personalize && echo "completed touch cmds"',
-  //   ]);
-
-  //   console.log("\n id  =  ", id, "\n");
-
-  //   console.log("\n====== init ==== stdout (", respInit.exitCode, "):");
-  //   console.log(respInit.stdout);
-  //   console.log("====== init ==== stderr:");
-  //   console.log(respInit.stderr);
-  //   console.log("======");
-  //   const resp = await execContainer(id, ["sh", "-c", instance.script]);
-  //   console.log("====== resp ==== stdout (", resp.exitCode, "):");
-  //   console.log(resp.stdout);
-  //   console.log("====== resp ==== stderr:");
-  //   console.log(resp.stderr);
-  //   console.log("======");
-  //   // await new Promise((resolve) => setTimeout(resolve, 100000000000));
-  //   const stdout = resp.stdout.trim().split("\n");
-  //   const stderr = resp.stderr.trim().split("\n");
-  //   expect(resp.exitCode).toBe(0);
-  //   expect(stdout).toEqual([""]);
-  // });
 });

--- a/personalize/main.test.ts
+++ b/personalize/main.test.ts
@@ -1,3 +1,4 @@
+import { readableStreamToText, spawn } from "bun";
 import { describe, expect, it } from "bun:test";
 import {
   executeScriptInContainer,
@@ -30,5 +31,21 @@ describe("personalize", async () => {
     ]);
   });
 
-
+//   it("runs with personalize script", async () => {
+//     const state = await runTerraformApply(import.meta.dir, {
+//       agent_id: "foo",
+//     });
+//     const instance = findResourceInstance(state, "coder_script");
+//     const id = await runContainer("alpine");
+//     const resp = await execContainer(id, ["sh", "-c", "touch ~/personalize && echo \"echo test\" > ~/personalize && chmod +x ~/personalize &&" + instance.script]);
+//     const stdout = resp.stdout.trim().split("\n");
+//     console.log("====== resp ==== stdout (", resp.exitCode, "):");
+//     console.log(resp.stdout);
+//     console.log("====== resp ==== stderr:");
+//     console.log(resp.stderr);
+//     console.log("======");
+//     // const stderr = resp.stderr.trim().split("\n");
+//     expect(resp.exitCode).toBe(0);
+//     expect(stdout).toEqual([""]);
+//   });
 });

--- a/personalize/main.test.ts
+++ b/personalize/main.test.ts
@@ -31,21 +31,31 @@ describe("personalize", async () => {
     ]);
   });
 
-//   it("runs with personalize script", async () => {
-//     const state = await runTerraformApply(import.meta.dir, {
-//       agent_id: "foo",
-//     });
-//     const instance = findResourceInstance(state, "coder_script");
-//     const id = await runContainer("alpine");
-//     const resp = await execContainer(id, ["sh", "-c", "touch ~/personalize && echo \"echo test\" > ~/personalize && chmod +x ~/personalize &&" + instance.script]);
-//     const stdout = resp.stdout.trim().split("\n");
-//     console.log("====== resp ==== stdout (", resp.exitCode, "):");
-//     console.log(resp.stdout);
-//     console.log("====== resp ==== stderr:");
-//     console.log(resp.stderr);
-//     console.log("======");
-//     // const stderr = resp.stderr.trim().split("\n");
-//     expect(resp.exitCode).toBe(0);
-//     expect(stdout).toEqual([""]);
-//   });
+  it("runs with personalize script", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+    });
+    const instance = findResourceInstance(state, "coder_script");
+    const id = await runContainer("alpine");
+    const respInit = await execContainer(id, ["sh", "-c", "touch ~/personalize && echo \"echo test\" > ~/personalize && chmod +x ~/personalize && echo \"completed touch cmds\""]);
+    
+    console.log("\n id  =  ", id, "\n")
+    
+    console.log("\n====== init ==== stdout (", respInit.exitCode, "):");
+    console.log(respInit.stdout);
+    console.log("====== init ==== stderr:");
+    console.log(respInit.stderr);
+    console.log("======");
+    const resp = await execContainer(id, ["sh", "-c", instance.script]);
+    console.log("====== resp ==== stdout (", resp.exitCode, "):");
+    console.log(resp.stdout);
+    console.log("====== resp ==== stderr:");
+    console.log(resp.stderr);
+    console.log("======");
+    // await new Promise((resolve) => setTimeout(resolve, 100000000000));
+    const stdout = resp.stdout.trim().split("\n");
+    const stderr = resp.stderr.trim().split("\n");
+    expect(resp.exitCode).toBe(0);
+    expect(stdout).toEqual([""]);
+  });
 });

--- a/personalize/main.test.ts
+++ b/personalize/main.test.ts
@@ -30,5 +30,4 @@ describe("personalize", async () => {
       "It will run every time your workspace starts. Use it to install personal packages!",
     ]);
   });
-
 });

--- a/personalize/main.test.ts
+++ b/personalize/main.test.ts
@@ -7,7 +7,7 @@ import {
   testRequiredVariables,
   runContainer,
   execContainer,
-  findResourceInstance
+  findResourceInstance,
 } from "../test";
 
 describe("personalize", async () => {
@@ -27,35 +27,39 @@ describe("personalize", async () => {
       "✨ \u001b[0;1mYou don't have a personalize script!",
       "",
       "Run \u001b[36;40;1mtouch ~/personalize && chmod +x ~/personalize\u001b[0m to create one.",
-      "It will run every time your workspace starts. Use it to install personal packages!"
+      "It will run every time your workspace starts. Use it to install personal packages!",
     ]);
   });
 
-  it("runs with personalize script", async () => {
-    const state = await runTerraformApply(import.meta.dir, {
-      agent_id: "foo",
-    });
-    const instance = findResourceInstance(state, "coder_script");
-    const id = await runContainer("alpine");
-    const respInit = await execContainer(id, ["sh", "-c", "touch ~/personalize && echo \"echo test\" > ~/personalize && chmod +x ~/personalize && echo \"completed touch cmds\""]);
-    
-    console.log("\n id  =  ", id, "\n")
-    
-    console.log("\n====== init ==== stdout (", respInit.exitCode, "):");
-    console.log(respInit.stdout);
-    console.log("====== init ==== stderr:");
-    console.log(respInit.stderr);
-    console.log("======");
-    const resp = await execContainer(id, ["sh", "-c", instance.script]);
-    console.log("====== resp ==== stdout (", resp.exitCode, "):");
-    console.log(resp.stdout);
-    console.log("====== resp ==== stderr:");
-    console.log(resp.stderr);
-    console.log("======");
-    // await new Promise((resolve) => setTimeout(resolve, 100000000000));
-    const stdout = resp.stdout.trim().split("\n");
-    const stderr = resp.stderr.trim().split("\n");
-    expect(resp.exitCode).toBe(0);
-    expect(stdout).toEqual([""]);
-  });
+  // it("runs with personalize script", async () => {
+  //   const state = await runTerraformApply(import.meta.dir, {
+  //     agent_id: "foo",
+  //   });
+  //   const instance = findResourceInstance(state, "coder_script");
+  //   const id = await runContainer("alpine");
+  //   const respInit = await execContainer(id, [
+  //     "sh",
+  //     "-c",
+  //     'touch ~/personalize && echo "echo test" > ~/personalize && chmod +x ~/personalize && echo "completed touch cmds"',
+  //   ]);
+
+  //   console.log("\n id  =  ", id, "\n");
+
+  //   console.log("\n====== init ==== stdout (", respInit.exitCode, "):");
+  //   console.log(respInit.stdout);
+  //   console.log("====== init ==== stderr:");
+  //   console.log(respInit.stderr);
+  //   console.log("======");
+  //   const resp = await execContainer(id, ["sh", "-c", instance.script]);
+  //   console.log("====== resp ==== stdout (", resp.exitCode, "):");
+  //   console.log(resp.stdout);
+  //   console.log("====== resp ==== stderr:");
+  //   console.log(resp.stderr);
+  //   console.log("======");
+  //   // await new Promise((resolve) => setTimeout(resolve, 100000000000));
+  //   const stdout = resp.stdout.trim().split("\n");
+  //   const stderr = resp.stderr.trim().split("\n");
+  //   expect(resp.exitCode).toBe(0);
+  //   expect(stdout).toEqual([""]);
+  // });
 });

--- a/personalize/main.test.ts
+++ b/personalize/main.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import {
+  executeScriptInContainer,
+  runTerraformApply,
+  runTerraformInit,
+  testRequiredVariables,
+  runContainer,
+  execContainer,
+  findResourceInstance
+} from "../test";
+
+describe("personalize", async () => {
+  await runTerraformInit(import.meta.dir);
+
+  testRequiredVariables(import.meta.dir, {
+    agent_id: "foo",
+  });
+
+  it("warns without personalize script", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+    });
+    const output = await executeScriptInContainer(state, "alpine");
+    expect(output.exitCode).toBe(0);
+    expect(output.stdout).toEqual([
+      "✨ \u001b[0;1mYou don't have a personalize script!",
+      "",
+      "Run \u001b[36;40;1mtouch ~/personalize && chmod +x ~/personalize\u001b[0m to create one.",
+      "It will run every time your workspace starts. Use it to install personal packages!"
+    ]);
+  });
+
+
+});

--- a/test.ts
+++ b/test.ts
@@ -129,7 +129,7 @@ export const findResourceInstance = <T extends "coder_script" | string>(
   return resource.instances[0].attributes as any;
 };
 
-// assertRequiredVariables creates a test-case
+// testRequiredVariables creates a test-case
 // for each variable provided and ensures that
 // the apply fails without it.
 export const testRequiredVariables = (

--- a/vscode-desktop/main.test.ts
+++ b/vscode-desktop/main.test.ts
@@ -13,15 +13,12 @@ describe("vscode-desktop", async () => {
     agent_id: "foo",
   });
 
-
   it("default output", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",
     });
     expect(state.outputs.vscode_url.value).toBe(
-      "vscode://coder.coder-remote/open?owner=default&workspace=default&token=$SESSION_TOKEN"
+      "vscode://coder.coder-remote/open?owner=default&workspace=default&token=$SESSION_TOKEN",
     );
   });
-
-
 });

--- a/vscode-desktop/main.test.ts
+++ b/vscode-desktop/main.test.ts
@@ -13,4 +13,15 @@ describe("vscode-desktop", async () => {
     agent_id: "foo",
   });
 
+
+  it("default output", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+    });
+    expect(state.outputs.vscode_url.value).toBe(
+      "vscode://coder.coder-remote/open?owner=default&workspace=default&token=$SESSION_TOKEN"
+    );
+  });
+
+
 });

--- a/vscode-desktop/main.test.ts
+++ b/vscode-desktop/main.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import {
+  executeScriptInContainer,
+  runTerraformApply,
+  runTerraformInit,
+  testRequiredVariables,
+} from "../test";
+
+describe("vscode-desktop", async () => {
+  await runTerraformInit(import.meta.dir);
+
+  testRequiredVariables(import.meta.dir, {
+    agent_id: "foo",
+  });
+
+});

--- a/vscode-desktop/main.tf
+++ b/vscode-desktop/main.tf
@@ -44,3 +44,8 @@ resource "coder_app" "vscode" {
     "&token=$SESSION_TOKEN",
   ])
 }
+
+output "vscode_url" {
+  value = coder_app.vscode.url
+  description = "VS Code Desktop URL."
+}

--- a/vscode-desktop/main.tf
+++ b/vscode-desktop/main.tf
@@ -16,7 +16,7 @@ variable "agent_id" {
 
 variable "folder" {
   type        = string
-  description = "The folder to opne in VS Code."
+  description = "The folder to open in VS Code."
   default     = ""
 }
 

--- a/vscode-desktop/main.tf
+++ b/vscode-desktop/main.tf
@@ -46,6 +46,6 @@ resource "coder_app" "vscode" {
 }
 
 output "vscode_url" {
-  value = coder_app.vscode.url
+  value       = coder_app.vscode.url
   description = "VS Code Desktop URL."
 }

--- a/vscode-web/main.test.ts
+++ b/vscode-web/main.test.ts
@@ -8,7 +8,6 @@ import {
 describe("vscode-web", async () => {
   await runTerraformInit(import.meta.dir);
 
-
   // replaces testRequiredVariables due to license variable
   // may add a testRequiredVariablesWithLicense function later
   it("missing agent_id", async () => {
@@ -17,21 +16,18 @@ describe("vscode-web", async () => {
         accept_license: "true",
       });
     } catch (ex) {
-      expect(ex.message).toContain(
-        'input variable "agent_id" is not set'
-      );
+      expect(ex.message).toContain('input variable "agent_id" is not set');
     }
   });
 
   it("invalid license_agreement", async () => {
-    
     try {
       await runTerraformApply(import.meta.dir, {
         agent_id: "foo",
       });
     } catch (ex) {
       expect(ex.message).toContain(
-        'You must accept the VS Code license agreement by setting accept_license=true'
+        "You must accept the VS Code license agreement by setting accept_license=true",
       );
     }
   });
@@ -61,8 +57,7 @@ describe("vscode-web", async () => {
       "🥳 vscode-cli has been installed.",
       "",
       "👷 Running /tmp/vscode-cli/bin/code serve-web --port 13338 --without-connection-token --accept-server-license-terms in the background...",
-      "Check logs at /tmp/vscode-web.log!"
+      "Check logs at /tmp/vscode-web.log!",
     ]);
   });
-
 });

--- a/vscode-web/main.test.ts
+++ b/vscode-web/main.test.ts
@@ -9,7 +9,8 @@ describe("vscode-web", async () => {
   await runTerraformInit(import.meta.dir);
 
 
-  // replaces testRequiredVariables due to license var
+  // replaces testRequiredVariables due to license variable
+  // may add a testRequiredVariablesWithLicense function later
   it("missing agent_id", async () => {
     try {
       await runTerraformApply(import.meta.dir, {

--- a/vscode-web/main.test.ts
+++ b/vscode-web/main.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import {
+  executeScriptInContainer,
+  runTerraformApply,
+  runTerraformInit,
+} from "../test";
+
+describe("vscode-web", async () => {
+  await runTerraformInit(import.meta.dir);
+
+
+  // replaces testRequiredVariables due to license var
+  it("missing agent_id", async () => {
+    try {
+      await runTerraformApply(import.meta.dir, {
+        accept_license: "true",
+      });
+    } catch (ex) {
+      expect(ex.message).toContain(
+        'input variable "agent_id" is not set'
+      );
+    }
+  });
+
+  it("invalid license_agreement", async () => {
+    
+    try {
+      await runTerraformApply(import.meta.dir, {
+        agent_id: "foo",
+      });
+    } catch (ex) {
+      expect(ex.message).toContain(
+        'You must accept the VS Code license agreement by setting accept_license=true'
+      );
+    }
+  });
+
+  it("fails without curl", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      accept_license: "true",
+    });
+    const output = await executeScriptInContainer(state, "alpine");
+    expect(output.exitCode).toBe(1);
+    expect(output.stdout).toEqual([
+      "\u001b[0;1mInstalling vscode-cli!",
+      "Failed to install vscode-cli:", // TODO: manually test error log
+    ]);
+  });
+
+  it("runs with curl", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      accept_license: "true",
+    });
+    const output = await executeScriptInContainer(state, "alpine/curl");
+    expect(output.exitCode).toBe(0);
+    expect(output.stdout).toEqual([
+      "\u001b[0;1mInstalling vscode-cli!",
+      "🥳 vscode-cli has been installed.",
+      "",
+      "👷 Running /tmp/vscode-cli/bin/code serve-web --port 13338 --without-connection-token --accept-server-license-terms in the background...",
+      "Check logs at /tmp/vscode-web.log!"
+    ]);
+  });
+
+});


### PR DESCRIPTION
## Overview
Many modules that only required simple test cases did not leverage the testing framework added by @kylecarbs. I added most of the missing tests, though some will require either a `coder_script` shell refactor like mentioned [here](https://github.com/coder/coder/issues/9769) or conversion to Bourne shell in their respective `run.sh` files. 

Another solution to the blocked tests may be using Dockerfiles with bun to test with required packages like coder and pip. 

Related to #65.

### Completed tests
- aws-region
- azure-region
- dotfiles
- filebrowser
- fly-region
- gcp-region
- git-clone
- git-config
- jetbrains-gateway
- jfrog
- vscode-web
- vscode-desktop

### WIP tests
- code-server
- personalize

### Todo tests
- coder-login (needs coder)
- jupyterlab (needs pip3)
- jupyter-notebook (needs pip3)
