### PR TITLE
code-server: fix multiple-extension installation

### DIFF
--- a/code-server/README.md
+++ b/code-server/README.md
@@ -63,6 +63,18 @@ module "settings" {
 }
 ```
 
+### Install multiple extensions
+
+Just run code-server in the background, don't fetch it from GitHub:
+
+```hcl
+module "settings" {
+    source = "https://registry.coder.com/modules/code-server"
+    agent_id = coder_agent.example.id
+    extensions = [ "dracula-theme.theme-dracula", "ms-azuretools.vscode-docker" ]
+}
+```
+
 ### Offline Mode
 
 Just run code-server in the background, don't fetch it from GitHub:

--- a/code-server/main.tf
+++ b/code-server/main.tf
@@ -66,7 +66,6 @@ resource "coder_script" "code-server" {
   agent_id     = var.agent_id
   display_name = "code-server"
   icon         = "/icon/code.svg"
-  shell        = "bash"
   script = templatefile("${path.module}/run.sh", {
     VERSION : var.install_version,
     EXTENSIONS : join(",", var.extensions),

--- a/code-server/main.tf
+++ b/code-server/main.tf
@@ -66,6 +66,7 @@ resource "coder_script" "code-server" {
   agent_id     = var.agent_id
   display_name = "code-server"
   icon         = "/icon/code.svg"
+  shell        = "bash"
   script = templatefile("${path.module}/run.sh", {
     VERSION : var.install_version,
     EXTENSIONS : join(",", var.extensions),

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -9,7 +9,7 @@ printf "ext string$${EXTENSIONS}"
 
 IFS=',' read -r -a extArr <<< "$${EXTENSIONS}"
 
-for i in "${extArr[@]}"; do
+for i in "$${extArr[@]}"; do
     echo " h: $i"
 done
 

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -5,6 +5,12 @@ BOLD='\033[0;1m'
 CODE='\033[36;40;1m'
 RESET='\033[0m'
 
+IFS=',' read -ra arr <<< "$names"
+
+for i in "${arr[@]}"; do
+    echo " h: $i"
+done
+
 printf "$${BOLD}Installing code-server!\n"
 
 ARGS=(

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 EXTENSIONS=("${EXTENSIONS}")
-IFS=',' read -ra arr <<< "$${EXTENSIONS}"
+IFS=',' read -ra EXTENSIONS <<< "$${EXTENSIONS}"
 BOLD='\033[0;1m'
 CODE='\033[36;40;1m'
 RESET='\033[0m'
@@ -10,7 +10,7 @@ printf "$${BOLD}Installing code-server!\n"
 
 # printf "$${BOLD}extensions: $${EXTENSIONS}\n"
 
-for ext in "$${EXTENSIONS[@]}"; do
+for ext in "${EXTENSIONS[@]}"; do
   printf "$${BOLD}extension: $${ext}\n"
 done
 

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# EXTENSIONS=("${EXTENSIONS}")
-IFS=',' read -ra arr <<< "$EXTENSIONS"
+EXTENSIONS=("${EXTENSIONS}")
+IFS=',' read -ra arr <<< "$${EXTENSIONS}"
 BOLD='\033[0;1m'
 CODE='\033[36;40;1m'
 RESET='\033[0m'

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -1,16 +1,11 @@
 #!/usr/bin/env bash
 
 EXTENSIONS=("${EXTENSIONS}")
-# IFS=',' read -ra exts <<< "$${EXTENSIONS}"
 BOLD='\033[0;1m'
 CODE='\033[36;40;1m'
 RESET='\033[0m'
 
 printf "$${BOLD}Installing code-server!\n"
-
-# for ext in "${exts[@]}"; do
-#   printf "$${BOLD}extension: $${ext}\n"
-# done
 
 ARGS=(
   "--method=standalone"

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -8,6 +8,8 @@ RESET='\033[0m'
 
 printf "$${BOLD}Installing code-server!\n"
 
+printf "$${BOLD}extensions: $${EXTENSIONS}!\n"
+
 ARGS=(
   "--method=standalone"
   "--prefix=${INSTALL_PREFIX}"

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -5,7 +5,9 @@ BOLD='\033[0;1m'
 CODE='\033[36;40;1m'
 RESET='\033[0m'
 
-IFS=',' read -r -a extArr <<< "$EXTENSIONS"
+printf "ext string$${EXTENSIONS}"
+
+IFS=',' read -r -a extArr <<< "$${EXTENSIONS}"
 
 for i in "${extArr[@]}"; do
     echo " h: $i"

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-EXTENSIONS=("${EXTENSIONS}")
+# EXTENSIONS=("${EXTENSIONS}")
+EXTENSIONS=',' read -ra arr <<< "${EXTENSIONS}"
 BOLD='\033[0;1m'
 CODE='\033[36;40;1m'
 RESET='\033[0m'

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# EXTENSIONS=("${EXTENSIONS}")
-EXTENSIONS=',' read -ra arr <<< "$EXTENSIONS"
+EXTENSIONS=("${EXTENSIONS}")
+EXTENSIONS=',' read -ra arr <<< "$${EXTENSIONS}"
 BOLD='\033[0;1m'
 CODE='\033[36;40;1m'
 RESET='\033[0m'

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 EXTENSIONS=("${EXTENSIONS}")
-IFS=',' read -ra arr <<< "$${EXTENSIONS}"
+# IFS=',' read -ra exts <<< "$${EXTENSIONS}"
 BOLD='\033[0;1m'
 CODE='\033[36;40;1m'
 RESET='\033[0m'
@@ -10,7 +10,7 @@ printf "$${BOLD}Installing code-server!\n"
 
 # printf "$${BOLD}extensions: $${EXTENSIONS}\n"
 
-for ext in "${arr[@]}"; do
+for ext in "${exts[@]}"; do
   printf "$${BOLD}extension: $${ext}\n"
 done
 

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-EXTENSIONS=("${EXTENSIONS}")
-IFS=',' read -ra extarr <<< "$${EXTENSIONS}"
+# EXTENSIONS=("${EXTENSIONS}")
+IFS=',' read -ra arr <<< "$EXTENSIONS"
 BOLD='\033[0;1m'
 CODE='\033[36;40;1m'
 RESET='\033[0m'
@@ -10,7 +10,7 @@ printf "$${BOLD}Installing code-server!\n"
 
 # printf "$${BOLD}extensions: $${EXTENSIONS}\n"
 
-for ext in "${extarr[@]}"; do
+for ext in "${arr[@]}"; do
   printf "$${BOLD}extension: $${ext}\n"
 done
 

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 
 # EXTENSIONS=("${EXTENSIONS}")
-EXTENSIONS=',' read -ra arr <<< "${EXTENSIONS}"
+EXTENSIONS=',' read -ra arr <<< "$EXTENSIONS"
 BOLD='\033[0;1m'
 CODE='\033[36;40;1m'
 RESET='\033[0m'
 
 printf "$${BOLD}Installing code-server!\n"
 
-printf "$${BOLD}extensions: $${EXTENSIONS}!\n"
+# printf "$${BOLD}extensions: $${EXTENSIONS}\n"
+
+for ext in "$${EXTENSIONS[@]}"; do
+  printf "$${BOLD}extension: $${ext}\n"
+done
 
 ARGS=(
   "--method=standalone"

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -8,11 +8,9 @@ RESET='\033[0m'
 
 printf "$${BOLD}Installing code-server!\n"
 
-# printf "$${BOLD}extensions: $${EXTENSIONS}\n"
-
-for ext in "${exts[@]}"; do
-  printf "$${BOLD}extension: $${ext}\n"
-done
+# for ext in "${exts[@]}"; do
+#   printf "$${BOLD}extension: $${ext}\n"
+# done
 
 ARGS=(
   "--method=standalone"

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 EXTENSIONS=("${EXTENSIONS}")
-IFS=',' read -ra EXTENSIONS <<< "$${EXTENSIONS}"
+IFS=',' read -ra extarr <<< "$${EXTENSIONS}"
 BOLD='\033[0;1m'
 CODE='\033[36;40;1m'
 RESET='\033[0m'
@@ -10,7 +10,7 @@ printf "$${BOLD}Installing code-server!\n"
 
 # printf "$${BOLD}extensions: $${EXTENSIONS}\n"
 
-for ext in "${EXTENSIONS[@]}"; do
+for ext in "${extarr[@]}"; do
   printf "$${BOLD}extension: $${ext}\n"
 done
 

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -5,9 +5,9 @@ BOLD='\033[0;1m'
 CODE='\033[36;40;1m'
 RESET='\033[0m'
 
-IFS=',' read -ra arr <<< "$names"
+IFS=',' read -r -a extArr <<< "$EXTENSIONS"
 
-for i in "${arr[@]}"; do
+for i in "${extArr[@]}"; do
     echo " h: $i"
 done
 

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -5,14 +5,6 @@ BOLD='\033[0;1m'
 CODE='\033[36;40;1m'
 RESET='\033[0m'
 
-printf "ext string$${EXTENSIONS}"
-
-IFS=',' read -r -a extArr <<< "$${EXTENSIONS}"
-
-for i in "$${extArr[@]}"; do
-    echo " h: $i"
-done
-
 printf "$${BOLD}Installing code-server!\n"
 
 ARGS=(
@@ -33,7 +25,8 @@ printf "🥳 code-server has been installed in ${INSTALL_PREFIX}\n\n"
 CODE_SERVER="${INSTALL_PREFIX}/bin/code-server"
 
 # Install each extension...
-for extension in "$${EXTENSIONS[@]}"; do
+IFS=',' read -r -a EXTENSIONLIST <<< "$${EXTENSIONS}"
+for extension in "$${EXTENSIONLIST[@]}"; do
   if [ -z "$extension" ]; then
     continue
   fi

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 EXTENSIONS=("${EXTENSIONS}")
-EXTENSIONS=',' read -ra arr <<< "$${EXTENSIONS}"
+IFS=',' read -ra arr <<< "$${EXTENSIONS}"
 BOLD='\033[0;1m'
 CODE='\033[36;40;1m'
 RESET='\033[0m'


### PR DESCRIPTION
The `code-server` module advertises the ability to add any number of extensions as a list of strings. There was an error in its implementation causing the script to fail when multiple extensions were specified (pointed out by #89). 

This fixes that issue by reading the comma-separated extension list into an array.