### PR TITLE
fix(git-clone): update the required provider version

### DIFF
--- a/git-clone/main.tf
+++ b/git-clone/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.11"
+      version = ">= 0.12"
     }
   }
 }


### PR DESCRIPTION
`coder_script` was introduced in [`v0.12.0`](https://registry.terraform.io/providers/coder/coder/0.12.0/docs/resources/script) and does not work on versions below this.