### PR TITLE
chore(jetbrans-gateway): update JetBrains IDEs and remove community editions

### DIFF
--- a/jetbrains-gateway/README.md
+++ b/jetbrains-gateway/README.md
@@ -17,7 +17,7 @@ module "jetbrains_gateway" {
   agent_id       = coder_agent.example.id
   agent_name     = "example"
   folder         = "/home/coder/example"
-  jetbrains_ides = ["GO", "WS", "IU", "PY", "PS", "CL", "RM", "DB", "RD"]
+  jetbrains_ides = ["GO", "WS", "IU", "PY", "PS", "CL", "RM"]
   default        = "PY"
 }
 ```
@@ -50,5 +50,3 @@ This module and JetBrains Gateway support the following JetBrains IDEs:
 - PhpStorm (`PS`)
 - CLion (`CL`)
 - RubyMine (`RM`)
-- DataGrip (`DB`)
-- Rider (`RD`)

--- a/jetbrains-gateway/README.md
+++ b/jetbrains-gateway/README.md
@@ -17,7 +17,8 @@ module "jetbrains_gateway" {
   agent_id       = coder_agent.example.id
   agent_name     = "example"
   folder         = "/home/coder/example"
-  jetbrains_ides = ["GO", "WS", "IU", "IC", "PY", "PC", "PS", "CL", "RM", "DB", "RD"]
+  jetbrains_ides = ["GO", "WS", "IU", "PY", "PS", "CL", "RM", "DB", "RD"]
+  default        = "PY"
 }
 ```
 
@@ -45,9 +46,7 @@ This module and JetBrains Gateway support the following JetBrains IDEs:
 - GoLand (`GO`)
 - WebStorm (`WS`)
 - IntelliJ IDEA Ultimate (`IU`)
-- IntelliJ IDEA Community (`IC`)
 - PyCharm Professional (`PY`)
-- PyCharm Community (`PC`)
 - PhpStorm (`PS`)
 - CLion (`CL`)
 - RubyMine (`RM`)

--- a/jetbrains-gateway/README.md
+++ b/jetbrains-gateway/README.md
@@ -15,7 +15,6 @@ This module adds a JetBrains Gateway Button to open any workspace with a single 
 module "jetbrains_gateway" {
   source         = "https://registry.coder.com/modules/jetbrains-gateway"
   agent_id       = coder_agent.example.id
-  agent_name     = "example"
   folder         = "/home/coder/example"
   jetbrains_ides = ["GO", "WS", "IU", "PY", "PS", "CL", "RM"]
   default        = "PY"
@@ -32,7 +31,6 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   source          = "https://registry.coder.com/modules/jetbrains-gateway"
   agent_id        = coder_agent.example.id
-  agent_name      = "example"
   folder          = "/home/coder/example"
   jetbrains_ides  = ["GO", "WS"]
   default         = "GO"

--- a/jetbrains-gateway/main.test.ts
+++ b/jetbrains-gateway/main.test.ts
@@ -2,7 +2,6 @@ import { it, expect, describe } from "bun:test";
 import {
   runTerraformInit,
   testRequiredVariables,
-  executeScriptInContainer,
   runTerraformApply,
 } from "../test";
 
@@ -11,7 +10,6 @@ describe("jetbrains-gateway", async () => {
 
   await testRequiredVariables(import.meta.dir, {
     agent_id: "foo",
-    agent_name: "bar",
     folder: "/baz/",
     jetbrains_ides: '["IU", "GO", "PY"]',
   });
@@ -19,7 +17,6 @@ describe("jetbrains-gateway", async () => {
   it("default to first ide", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",
-      agent_name: "bar",
       folder: "/baz/",
       jetbrains_ides: '["IU", "GO", "PY"]',
     });

--- a/jetbrains-gateway/main.test.ts
+++ b/jetbrains-gateway/main.test.ts
@@ -13,7 +13,7 @@ describe("jetbrains-gateway", async () => {
     agent_id: "foo",
     agent_name: "bar",
     folder: "/baz/",
-    jetbrains_ides: '["IU", "IC", "PY"]',
+    jetbrains_ides: '["IU", "GO", "PY"]',
   });
 
   it("default to first ide", async () => {
@@ -21,10 +21,10 @@ describe("jetbrains-gateway", async () => {
       agent_id: "foo",
       agent_name: "bar",
       folder: "/baz/",
-      jetbrains_ides: '["IU", "IC", "PY"]',
+      jetbrains_ides: '["IU", "GO", "PY"]',
     });
     expect(state.outputs.jetbrains_ides.value).toBe(
-      '["IU","232.9921.47","https://download.jetbrains.com/idea/ideaIU-2023.2.2.tar.gz"]',
+      '["IU","232.10203.10","https://download.jetbrains.com/idea/ideaIU-2023.2.4.tar.gz"]',
     );
   });
 });

--- a/jetbrains-gateway/main.test.ts
+++ b/jetbrains-gateway/main.test.ts
@@ -11,7 +11,6 @@ describe("jetbrains-gateway", async () => {
   await testRequiredVariables(import.meta.dir, {
     agent_id: "foo",
     folder: "/baz/",
-    jetbrains_ides: '["IU", "GO", "PY"]',
   });
 
   it("default to first ide", async () => {

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -14,11 +14,6 @@ variable "agent_id" {
   description = "The ID of a Coder agent."
 }
 
-variable "agent_name" {
-  type        = string
-  description = "The name of a Coder agent."
-}
-
 variable "folder" {
   type        = string
   description = "The directory to open in the IDE. e.g. /home/coder/project"
@@ -133,8 +128,8 @@ resource "coder_app" "gateway" {
   url = join("", [
     "jetbrains-gateway://connect#type=coder&workspace=",
     data.coder_workspace.me.name,
-    "&agent=",
-    var.agent_name,
+    "&agent_id=",
+    var.agent_id,
     "&folder=",
     var.folder,
     "&url=",

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -36,10 +36,10 @@ variable "jetbrains_ides" {
   validation {
     condition = (
       alltrue([
-        for code in var.jetbrains_ides : contains(["IU", "IC", "PS", "WS", "PY", "PC", "CL", "GO", "DB", "RD", "RM"], code)
+        for code in var.jetbrains_ides : contains(["IU", "PS", "WS", "PY", "CL", "GO", "DB", "RD", "RM"], code)
       ])
     )
-    error_message = "The jetbrains_ides must be a list of valid product codes. Valid product codes are: IU, IC, PS, WS, PY, PC, CL, GO, DB, RD, RM."
+    error_message = "The jetbrains_ides must be a list of valid product codes. Valid product codes are: IU, PS, WS, PY, CL, GO, DB, RD, RM."
   }
   # check if the list is empty
   validation {
@@ -70,20 +70,10 @@ locals {
       name  = "IntelliJ IDEA Ultimate",
       value = jsonencode(["IU", "232.10203.10", "https://download.jetbrains.com/idea/ideaIU-2023.2.4.tar.gz"])
     },
-    "IC" = {
-      icon  = "/icon/intellij.svg",
-      name  = "IntelliJ IDEA Community",
-      value = jsonencode(["IC", "232.10203.10", "https://download.jetbrains.com/idea/ideaIC-2023.2.2.tar.gz"])
-    },
     "PY" = {
       icon  = "/icon/pycharm.svg",
       name  = "PyCharm Professional",
       value = jsonencode(["PY", "232.10203.26", "https://download.jetbrains.com/python/pycharm-professional-2023.2.4.tar.gz"])
-    },
-    "PC" = {
-      icon  = "/icon/pycharm.svg",
-      name  = "PyCharm Community",
-      value = jsonencode(["PC", "232.10203.26", "https://download.jetbrains.com/python/pycharm-community-2023.2.4.tar.gz"])
     },
     "RD" = {
       icon  = "/icon/rider.svg",

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -28,6 +28,7 @@ variable "default" {
 variable "jetbrains_ides" {
   type        = list(string)
   description = "The list of IDE product codes."
+  default     = ["IU", "PS", "WS", "PY", "CL", "GO", "RM"]
   validation {
     condition = (
       alltrue([

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -31,10 +31,10 @@ variable "jetbrains_ides" {
   validation {
     condition = (
       alltrue([
-        for code in var.jetbrains_ides : contains(["IU", "PS", "WS", "PY", "CL", "GO", "DB", "RD", "RM"], code)
+        for code in var.jetbrains_ides : contains(["IU", "PS", "WS", "PY", "CL", "GO", "RM"], code)
       ])
     )
-    error_message = "The jetbrains_ides must be a list of valid product codes. Valid product codes are: IU, PS, WS, PY, CL, GO, DB, RD, RM."
+    error_message = "The jetbrains_ides must be a list of valid product codes. Valid product codes are IU, PS, WS, PY, CL, GO, RM."
   }
   # check if the list is empty
   validation {
@@ -70,20 +70,10 @@ locals {
       name  = "PyCharm Professional",
       value = jsonencode(["PY", "232.10203.26", "https://download.jetbrains.com/python/pycharm-professional-2023.2.4.tar.gz"])
     },
-    "RD" = {
-      icon  = "/icon/rider.svg",
-      name  = "Rider",
-      value = jsonencode(["RD", "232.10203.29", "https://download.jetbrains.com/rider/JetBrains.Rider-2023.2.3.tar.gz"])
-    }
     "CL" = {
       icon  = "/icon/clion.svg",
       name  = "CLion",
       value = jsonencode(["CL", "232.9921.42", "https://download.jetbrains.com/cpp/CLion-2023.2.2.tar.gz"])
-    },
-    "DB" = {
-      icon  = "/icon/datagrip.svg",
-      name  = "DataGrip",
-      value = jsonencode(["DB", "232.10203.8", "https://download.jetbrains.com/datagrip/datagrip-2023.2.3.tar.gz"])
     },
     "PS" = {
       icon  = "/icon/phpstorm.svg",

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -58,37 +58,37 @@ locals {
     "GO" = {
       icon  = "/icon/goland.svg",
       name  = "GoLand",
-      value = jsonencode(["GO", "232.9921.53", "https://download.jetbrains.com/go/goland-2023.2.2.tar.gz"])
+      value = jsonencode(["GO", "232.10203.20", "https://download.jetbrains.com/go/goland-2023.2.4.tar.gz"])
     },
     "WS" = {
       icon  = "/icon/webstorm.svg",
       name  = "WebStorm",
-      value = jsonencode(["WS", "232.9921.42", "https://download.jetbrains.com/webstorm/WebStorm-2023.2.2.tar.gz"])
+      value = jsonencode(["WS", "232.10203.14", "https://download.jetbrains.com/webstorm/WebStorm-2023.2.4.tar.gz"])
     },
     "IU" = {
       icon  = "/icon/intellij.svg",
       name  = "IntelliJ IDEA Ultimate",
-      value = jsonencode(["IU", "232.9921.47", "https://download.jetbrains.com/idea/ideaIU-2023.2.2.tar.gz"])
+      value = jsonencode(["IU", "232.10203.10", "https://download.jetbrains.com/idea/ideaIU-2023.2.4.tar.gz"])
     },
     "IC" = {
       icon  = "/icon/intellij.svg",
       name  = "IntelliJ IDEA Community",
-      value = jsonencode(["IC", "232.9921.47", "https://download.jetbrains.com/idea/ideaIC-2023.2.2.tar.gz"])
+      value = jsonencode(["IC", "232.10203.10", "https://download.jetbrains.com/idea/ideaIC-2023.2.2.tar.gz"])
     },
     "PY" = {
       icon  = "/icon/pycharm.svg",
       name  = "PyCharm Professional",
-      value = jsonencode(["PY", "232.9559.58", "https://download.jetbrains.com/python/pycharm-professional-2023.2.1.tar.gz"])
+      value = jsonencode(["PY", "232.10203.26", "https://download.jetbrains.com/python/pycharm-professional-2023.2.4.tar.gz"])
     },
     "PC" = {
       icon  = "/icon/pycharm.svg",
       name  = "PyCharm Community",
-      value = jsonencode(["PC", "232.9559.58", "https://download.jetbrains.com/python/pycharm-community-2023.2.1.tar.gz"])
+      value = jsonencode(["PC", "232.10203.26", "https://download.jetbrains.com/python/pycharm-community-2023.2.4.tar.gz"])
     },
     "RD" = {
       icon  = "/icon/rider.svg",
       name  = "Rider",
-      value = jsonencode(["RD", "232.9559.61", "https://download.jetbrains.com/rider/JetBrains.Rider-2023.2.1.tar.gz"])
+      value = jsonencode(["RD", "232.10203.29", "https://download.jetbrains.com/rider/JetBrains.Rider-2023.2.3.tar.gz"])
     }
     "CL" = {
       icon  = "/icon/clion.svg",
@@ -98,17 +98,17 @@ locals {
     "DB" = {
       icon  = "/icon/datagrip.svg",
       name  = "DataGrip",
-      value = jsonencode(["DB", "232.9559.28", "https://download.jetbrains.com/datagrip/datagrip-2023.2.1.tar.gz"])
+      value = jsonencode(["DB", "232.10203.8", "https://download.jetbrains.com/datagrip/datagrip-2023.2.3.tar.gz"])
     },
     "PS" = {
       icon  = "/icon/phpstorm.svg",
       name  = "PhpStorm",
-      value = jsonencode(["PS", "232.9559.64", "https://download.jetbrains.com/webide/PhpStorm-2023.2.1.tar.gz"])
+      value = jsonencode(["PS", "232.10072.32", "https://download.jetbrains.com/webide/PhpStorm-2023.2.3.tar.gz"])
     },
     "RM" = {
       icon  = "/icon/rubymine.svg",
       name  = "RubyMine",
-      value = jsonencode(["RM", "232.9921.48", "https://download.jetbrains.com/ruby/RubyMine-2023.2.2.tar.gz"])
+      value = jsonencode(["RM", "232.10203.15", "https://download.jetbrains.com/ruby/RubyMine-2023.2.4.tar.gz"])
     }
   }
 }


### PR DESCRIPTION
Another try at #96. I cannot reproduce the error on deployment and dev.coder.com.

It also removes Community editions, `Rider`, and `DataGrip` as they are not supported for Remote Development.