### PR TITLE
fix(jfrog-token)!: add attributes to fine control the token behaviour

### DIFF
--- a/jfrog-token/README.md
+++ b/jfrog-token/README.md
@@ -16,8 +16,8 @@ Install the JF CLI and authenticate package managers with Artifactory using Arti
 module "jfrog" {
     source = "https://registry.coder.com/modules/jfrog-token"
     agent_id = coder_agent.example.id
-    jfrog_url = "https://YYYY.jfrog.io"
-    artifactory_access_token = var.artifactory_access_token # An admin access token
+    jfrog_url = "https://XXXX.jfrog.io"
+    artifactory_access_token = var.artifactory_access_token
     package_managers = {
       "npm": "npm",
       "go": "go",
@@ -26,7 +26,7 @@ module "jfrog" {
 }
 ```
 
-Get a JFrog access token from your Artifactory instance. The token must have admin permissions. It is recommended to store the token in a secret terraform variable.
+Get a JFrog access token from your Artifactory instance. The token must be an [admin token](https://registry.terraform.io/providers/jfrog/artifactory/latest/docs#access-token). It is recommended to store the token in a secret terraform variable.
 
 ```hcl
 variable "artifactory_access_token" {

--- a/jfrog-token/main.tf
+++ b/jfrog-token/main.tf
@@ -25,8 +25,8 @@ variable "artifactory_access_token" {
 
 variable "check_license" {
   type        = bool
-  description = "If your usage doesn't require a license, you can set `check_license` attribute to `false` to skip this check."
-  deafult     = true
+  description = "Toggle for pre-flight checking of Artifactory license. Default to `true`."
+  default     = true
 }
 
 variable "username_field" {

--- a/jfrog-token/main.tf
+++ b/jfrog-token/main.tf
@@ -43,8 +43,8 @@ variable "expires_in" {
 
 variable "username_field" {
   type        = string
-  description = "The field to use for the artifactory username. i.e. Coder username or email."
-  default     = "email"
+  description = "The field to use for the artifactory username. Default `username`."
+  default     = "username"
   validation {
     condition     = can(regex("^(email|username)$", var.username_field))
     error_message = "username_field must be either 'email' or 'username'"

--- a/jfrog-token/main.tf
+++ b/jfrog-token/main.tf
@@ -29,6 +29,18 @@ variable "check_license" {
   default     = true
 }
 
+variable "refreshable" {
+  type        = bool
+  description = "Is this token refreshable? Default is `false`."
+  default     = false
+}
+
+variable "expires_in" {
+  type        = bool
+  description = "The amount of time, in seconds, it would take for the token to expire."
+  default     = null
+}
+
 variable "username_field" {
   type        = string
   description = "The field to use for the artifactory username. i.e. Coder username or email."
@@ -74,7 +86,8 @@ resource "artifactory_scoped_token" "me" {
   # which fails validation.
   username    = length(local.username) > 0 ? local.username : "dummy"
   scopes      = ["applied-permissions/user"]
-  refreshable = true
+  refreshable = var.refreshable
+  expires_in  = var.expires_in
 }
 
 data "coder_workspace" "me" {}

--- a/jfrog-token/main.tf
+++ b/jfrog-token/main.tf
@@ -26,7 +26,7 @@ variable "artifactory_access_token" {
 variable "check_license" {
   type        = bool
   description = "If your usage doesn't require a license, you can set `check_license` attribute to `false` to skip this check."
-  deafult     = false
+  deafult     = true
 }
 
 variable "username_field" {

--- a/jfrog-token/main.tf
+++ b/jfrog-token/main.tf
@@ -23,6 +23,12 @@ variable "artifactory_access_token" {
   description = "The admin-level access token to use for JFrog."
 }
 
+variable "check_license" {
+  type        = bool
+  description = "If your usage doesn't require a license, you can set `check_license` attribute to `false` to skip this check."
+  deafult     = false
+}
+
 variable "username_field" {
   type        = string
   description = "The field to use for the artifactory username. i.e. Coder username or email."
@@ -58,8 +64,9 @@ locals {
 
 # Configure the Artifactory provider
 provider "artifactory" {
-  url          = join("/", [var.jfrog_url, "artifactory"])
-  access_token = var.artifactory_access_token
+  url           = join("/", [var.jfrog_url, "artifactory"])
+  access_token  = var.artifactory_access_token
+  check_license = var.check_license
 }
 
 resource "artifactory_scoped_token" "me" {

--- a/jfrog-token/main.tf
+++ b/jfrog-token/main.tf
@@ -36,7 +36,7 @@ variable "refreshable" {
 }
 
 variable "expires_in" {
-  type        = bool
+  type        = number
   description = "The amount of time, in seconds, it would take for the token to expire."
   default     = null
 }


### PR DESCRIPTION
1. Add the [`check_license`](https://registry.terraform.io/providers/jfrog/artifactory/latest/docs#check_license) attribute to skip the pre-flight license check.
2. Add the [`expires_in`](https://registry.terraform.io/providers/jfrog/artifactory/latest/docs/resources/scoped_token#expires_in) attribute to control the `expiry time of scoped_tokens used in the workspace.
3. Make the [`refreshable`](https://registry.terraform.io/providers/jfrog/artifactory/latest/docs/resources/scoped_token#refreshable) attribute an input to control if the tokens are refreshable.
4. Change the `username_filed` default value to `username` instead of `email`. This will now map the [`data.coder_workspace.me.owner`](https://registry.terraform.io/providers/coder/coder/latest/docs/data-sources/workspace#owner) to [`username`](https://registry.terraform.io/providers/jfrog/artifactory/latest/docs/resources/scoped_token#username). 
	> This is the observed behavior on both self-hosted and SaaS Artifactory instances for GitHub and Google OAuth provisioned users. If this is not the case for some customers, they can use this field to change this behavior.

> [!NOTE]
> All values default to [`artifactory_scoped_token`](https://registry.terraform.io/providers/jfrog/artifactory/latest/docs/resources/scoped_token) default values.