### PR TITLE
Add missing URL to VS Code desktop module

### DIFF
--- a/vscode-desktop/main.tf
+++ b/vscode-desktop/main.tf
@@ -35,6 +35,8 @@ resource "coder_app" "vscode" {
     data.coder_workspace.me.name,
     "&folder=",
     var.folder,
+    "&url=",
+    data.coder_workspace.me.access_url,
     "&token=$SESSION_TOKEN",
     ]) : join("", [
     "vscode://coder.coder-remote/open?owner=",


### PR DESCRIPTION
Without this the plugin will only work if the user has happened to log in before and that URL was previously saved (and it is the right URL for whatever workspace they are trying to connect).  Otherwise, they get an error about localhost (or if the URL is for a different deployment they would get some other issues).

Fixes https://github.com/coder/coder/issues/10896.