### PR TITLE
fix(code-server): write settings to User

### DIFF
--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -39,10 +39,10 @@ for extension in "$${EXTENSIONLIST[@]}"; do
 done
 
 # Check if the settings file exists...
-if [ ! -f ~/.local/share/code-server/Machine/settings.json ]; then
+if [ ! -f ~/.local/share/code-server/User/settings.json ]; then
   echo "⚙️ Creating settings file..."
-  mkdir -p ~/.local/share/code-server/Machine
-  echo "${SETTINGS}" > ~/.local/share/code-server/Machine/settings.json
+  mkdir -p ~/.local/share/code-server/User
+  echo "${SETTINGS}" > ~/.local/share/code-server/User/settings.json
 fi
 
 echo "👷 Running code-server in the background..."


### PR DESCRIPTION
Fixes #118

> Not all settings will work with Machine. For example update.mode seems to only be valid for User settings and placing it in Machine will have no effect. So a scope option will probably be necessary (or it will need to default to User).

Changing default to `User`