### PR TITLE
feat!(git-clone): change `path` input to `base_dir` and return `repo_dir` as output

### DIFF
--- a/git-clone/README.md
+++ b/git-clone/README.md
@@ -38,6 +38,6 @@ module "git-clone" {
   version  = "1.0.0"
   agent_id = coder_agent.example.id
   url      = "https://github.com/coder/coder"
-  path     = "~/projects/coder/coder"
+  path     = "~/projects/coder"
 }
 ```

--- a/git-clone/README.md
+++ b/git-clone/README.md
@@ -9,7 +9,7 @@ tags: [git, helper]
 
 # Git Clone
 
-This module allows you to automatically clone a repository by URL and skip if it exists in the path provided.
+This module allows you to automatically clone a repository by URL and skip if it exists in the base directory provided.
 
 ```hcl
 module "git-clone" {
@@ -38,6 +38,6 @@ module "git-clone" {
   version  = "1.0.0"
   agent_id = coder_agent.example.id
   url      = "https://github.com/coder/coder"
-  path     = "~/projects/coder"
+  base_dir = "~/projects/coder"
 }
 ```

--- a/git-clone/main.tf
+++ b/git-clone/main.tf
@@ -25,10 +25,19 @@ variable "agent_id" {
   type        = string
 }
 
+locals {
+  clone_path = var.path != "" ? join("/", [var.path, replace(basename(var.url), ".git", "")]) : join("/", ["~", replace(basename(var.url), ".git", "")])
+}
+
+output "repo_dir" {
+  value       = local.clone_path
+  description = "Full path of cloned repo directory"
+}
+
 resource "coder_script" "git_clone" {
   agent_id = var.agent_id
   script = templatefile("${path.module}/run.sh", {
-    CLONE_PATH = var.path != "" ? join("/", [var.path, replace(basename(var.url), ".git", "")]) : join("/", ["~", replace(basename(var.url), ".git", "")])
+    CLONE_PATH = local.clone_path
     REPO_URL : var.url,
   })
   display_name       = "Git Clone"

--- a/git-clone/main.tf
+++ b/git-clone/main.tf
@@ -14,9 +14,9 @@ variable "url" {
   type        = string
 }
 
-variable "path" {
+variable "base_dir" {
   default     = ""
-  description = "The path to clone the repository. Defaults to \"$HOME/<basename of url>\"."
+  description = "The base directory to clone the repository. Defaults to \"$HOME\"."
   type        = string
 }
 
@@ -26,7 +26,7 @@ variable "agent_id" {
 }
 
 locals {
-  clone_path = var.path != "" ? join("/", [var.path, replace(basename(var.url), ".git", "")]) : join("/", ["~", replace(basename(var.url), ".git", "")])
+  clone_path = var.base_dir != "" ? join("/", [var.base_dir, replace(basename(var.url), ".git", "")]) : join("/", ["~", replace(basename(var.url), ".git", "")])
 }
 
 output "repo_dir" {


### PR DESCRIPTION
After #124, we now automatically append the `path` with the `repo` name, so the example should be changed to pass only the base directory as the `path` input.