### PR TITLE
feat(dotfiles): add ability to apply dotfiles as root

### DIFF
--- a/dotfiles/main.tf
+++ b/dotfiles/main.tf
@@ -25,13 +25,10 @@ data "coder_parameter" "dotfiles_uri" {
 }
 
 resource "coder_script" "personalize" {
-  agent_id     = var.agent_id
-  script       = <<-EOT
-    DOTFILES_URI="${data.coder_parameter.dotfiles_uri.value}"
-    if [ -n "$${DOTFILES_URI// }" ]; then
-    coder dotfiles "$DOTFILES_URI" -y 2>&1 | tee -a ~/.dotfiles.log
-    fi
-    EOT
+  agent_id = var.agent_id
+  script = templatefile("${path.module}/run.sh", {
+    DOTFILES_URI : data.coder_parameter.dotfiles_uri.value,
+  })
   display_name = "Dotfiles"
   icon         = "/icon/dotfiles.svg"
   run_on_start = true

--- a/dotfiles/run.sh
+++ b/dotfiles/run.sh
@@ -1,0 +1,7 @@
+DOTFILES_URI="${DOTFILES_URI}"
+ROOT="${ROOT}"
+
+if [ -n "$${DOTFILES_URI// }" ]; then
+  echo "✨ Applying dotfiles for user $USER"
+  coder dotfiles "$DOTFILES_URI" -y 2>&1 | tee -a ~/.dotfiles.log
+fi


### PR DESCRIPTION
In my template ([basic-env](https://github.com/uwu/basic-env)), dotfiles are also applied to root.
I like doing this because whenever switching to a root shell for more than one command (e.g installing packages, etc), my shell is consistent with my user.

I have added a `root` parameter to the module which will apply the dotfiles using `sudo`.

---

```tf
module "dotfiles" {
  source = "git::https://github.com/phorcys420/coder-modules.git//dotfiles?ref=dotfiles-root"
  agent_id = coder_agent.dev.id
  root = true
}
```