### PR TITLE
chore: add prettier terraform formatting in markdown files

### DIFF
--- a/.sample/README.md
+++ b/.sample/README.md
@@ -11,7 +11,7 @@ tags: [helper]
 
 <!-- Describes what this module does -->
 
-```hcl
+```tf
 module "MODULE_NAME" {
   source = "registry.coder.com/modules/MODULE_NAME/coder"
   version = "1.0.0"
@@ -26,7 +26,7 @@ module "MODULE_NAME" {
 
 Install the Dracula theme from [OpenVSX](https://open-vsx.org/):
 
-```hcl
+```tf
 module "MODULE_NAME" {
   source = "registry.coder.com/modules/MODULE_NAME/coder"
   version = "1.0.0"
@@ -43,7 +43,7 @@ Enter the `<author>.<name>` into the extensions array and code-server will autom
 
 Configure VS Code's [settings.json](https://code.visualstudio.com/docs/getstarted/settings#_settingsjson) file:
 
-```hcl
+```tf
 module "MODULE_NAME" {
   source = "registry.coder.com/modules/MODULE_NAME/coder"
   version = "1.0.0"
@@ -59,7 +59,7 @@ module "MODULE_NAME" {
 
 Run code-server in the background, don't fetch it from GitHub:
 
-```hcl
+```tf
 module "MODULE_NAME" {
   source = "registry.coder.com/modules/MODULE_NAME/coder"
   version = "1.0.0"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ $ bun test -t '<module>'
 
 You can test a module locally by updating the source as follows
 
-```hcl
+```tf
 module "example" {
   source = "git::https://github.com/<USERNAME>/<REPO>.git//<MODULE-NAME>?ref=<BRANCH-NAME>"
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Modules extend Templates to create reusable components for your development envi
 
 e.g.
 
-```hcl
+```tf
 module "code-server" {
   source = "registry.coder.com/modules/code-server/coder"
   version = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ e.g.
 
 ```tf
 module "code-server" {
-  source = "registry.coder.com/modules/code-server/coder"
-  version = "1.0.0"
+  source   = "registry.coder.com/modules/code-server/coder"
+  version  = "1.0.0"
   agent_id = coder_agent.main.id
 }
 ```

--- a/aws-region/README.md
+++ b/aws-region/README.md
@@ -16,7 +16,7 @@ Customize the preselected parameter value:
 
 ```tf
 module "aws-region" {
-  source = "registry.coder.com/modules/aws-region/coder"
+  source  = "registry.coder.com/modules/aws-region/coder"
   version = "1.0.0"
   default = "us-east-1"
 }
@@ -36,14 +36,14 @@ Change the display name and icon for a region using the corresponding maps:
 
 ```tf
 module "aws-region" {
-  source = "registry.coder.com/modules/aws-region/coder"
+  source  = "registry.coder.com/modules/aws-region/coder"
   version = "1.0.0"
   default = "ap-south-1"
   custom_names = {
-    "ap-south-1": "Awesome Mumbai!"
+    "ap-south-1" : "Awesome Mumbai!"
   }
   custom_icons = {
-    "ap-south-1": "/emojis/1f33a.png"
+    "ap-south-1" : "/emojis/1f33a.png"
   }
 }
 
@@ -60,9 +60,9 @@ Hide the Asia Pacific regions Seoul and Osaka:
 
 ```tf
 module "aws-region" {
-  source = "registry.coder.com/modules/aws-region/coder"
+  source  = "registry.coder.com/modules/aws-region/coder"
   version = "1.0.0"
-  exclude = [ "ap-northeast-2", "ap-northeast-3" ]
+  exclude = ["ap-northeast-2", "ap-northeast-3"]
 }
 
 provider "aws" {

--- a/aws-region/README.md
+++ b/aws-region/README.md
@@ -14,7 +14,7 @@ the region closest to them.
 
 Customize the preselected parameter value:
 
-```hcl
+```tf
 module "aws-region" {
   source = "registry.coder.com/modules/aws-region/coder"
   version = "1.0.0"
@@ -34,7 +34,7 @@ provider "aws" {
 
 Change the display name and icon for a region using the corresponding maps:
 
-```hcl
+```tf
 module "aws-region" {
   source = "registry.coder.com/modules/aws-region/coder"
   version = "1.0.0"
@@ -58,7 +58,7 @@ provider "aws" {
 
 Hide the Asia Pacific regions Seoul and Osaka:
 
-```hcl
+```tf
 module "aws-region" {
   source = "registry.coder.com/modules/aws-region/coder"
   version = "1.0.0"

--- a/azure-region/README.md
+++ b/azure-region/README.md
@@ -11,7 +11,7 @@ tags: [helper, parameter, azure, regions]
 
 This module adds a parameter with all Azure regions, allowing developers to select the region closest to them.
 
-```hcl
+```tf
 module "azure_region" {
   source = "registry.coder.com/modules/azure-region/coder"
   version = "1.0.0"
@@ -31,7 +31,7 @@ resource "azurem_resource_group" "example" {
 
 Change the display name and icon for a region using the corresponding maps:
 
-```hcl
+```tf
 module "azure-region" {
   source = "registry.coder.com/modules/azure-region/coder"
   version = "1.0.0"
@@ -54,7 +54,7 @@ resource "azurerm_resource_group" "example" {
 
 Hide all regions in Australia except australiacentral:
 
-```hcl
+```tf
 module "azure-region" {
   source = "registry.coder.com/modules/azure-region/coder"
   version = "1.0.0"

--- a/azure-region/README.md
+++ b/azure-region/README.md
@@ -13,7 +13,7 @@ This module adds a parameter with all Azure regions, allowing developers to sele
 
 ```tf
 module "azure_region" {
-  source = "registry.coder.com/modules/azure-region/coder"
+  source  = "registry.coder.com/modules/azure-region/coder"
   version = "1.0.0"
   default = "eastus"
 }
@@ -33,13 +33,13 @@ Change the display name and icon for a region using the corresponding maps:
 
 ```tf
 module "azure-region" {
-  source = "registry.coder.com/modules/azure-region/coder"
+  source  = "registry.coder.com/modules/azure-region/coder"
   version = "1.0.0"
   custom_names = {
-    "australia": "Go Australia!"
+    "australia" : "Go Australia!"
   }
   custom_icons = {
-    "australia": "/icons/smiley.svg"
+    "australia" : "/icons/smiley.svg"
   }
 }
 
@@ -56,7 +56,7 @@ Hide all regions in Australia except australiacentral:
 
 ```tf
 module "azure-region" {
-  source = "registry.coder.com/modules/azure-region/coder"
+  source  = "registry.coder.com/modules/azure-region/coder"
   version = "1.0.0"
   exclude = [
     "australia",

--- a/code-server/README.md
+++ b/code-server/README.md
@@ -13,8 +13,8 @@ Automatically install [code-server](https://github.com/coder/code-server) in a w
 
 ```tf
 module "code-server" {
-  source = "registry.coder.com/modules/code-server/coder"
-  version = "1.0.0"
+  source   = "registry.coder.com/modules/code-server/coder"
+  version  = "1.0.0"
   agent_id = coder_agent.example.id
 }
 ```
@@ -40,8 +40,8 @@ Install the Dracula theme from [OpenVSX](https://open-vsx.org/):
 
 ```tf
 module "code-server" {
-  source = "registry.coder.com/modules/code-server/coder"
-  version = "1.0.0"
+  source   = "registry.coder.com/modules/code-server/coder"
+  version  = "1.0.0"
   agent_id = coder_agent.example.id
   extensions = [
     "dracula-theme.theme-dracula"
@@ -57,10 +57,10 @@ Configure VS Code's [settings.json](https://code.visualstudio.com/docs/getstarte
 
 ```tf
 module "settings" {
-  source = "registry.coder.com/modules/code-server/coder"
-  version = "1.0.0"
-  agent_id = coder_agent.example.id
-  extensions = [ "dracula-theme.theme-dracula" ]
+  source     = "registry.coder.com/modules/code-server/coder"
+  version    = "1.0.0"
+  agent_id   = coder_agent.example.id
+  extensions = ["dracula-theme.theme-dracula"]
   settings = {
     "workbench.colorTheme" = "Dracula"
   }
@@ -73,10 +73,10 @@ Just run code-server in the background, don't fetch it from GitHub:
 
 ```tf
 module "settings" {
-  source = "registry.coder.com/modules/code-server/coder"
-  version = "1.0.0"
-  agent_id = coder_agent.example.id
-  extensions = [ "dracula-theme.theme-dracula", "ms-azuretools.vscode-docker" ]
+  source     = "registry.coder.com/modules/code-server/coder"
+  version    = "1.0.0"
+  agent_id   = coder_agent.example.id
+  extensions = ["dracula-theme.theme-dracula", "ms-azuretools.vscode-docker"]
 }
 ```
 
@@ -86,9 +86,9 @@ Just run code-server in the background, don't fetch it from GitHub:
 
 ```tf
 module "settings" {
-  source = "registry.coder.com/modules/code-server/coder"
-  version = "1.0.0"
+  source   = "registry.coder.com/modules/code-server/coder"
+  version  = "1.0.0"
   agent_id = coder_agent.example.id
-  offline = true
+  offline  = true
 }
 ```

--- a/code-server/README.md
+++ b/code-server/README.md
@@ -11,7 +11,7 @@ tags: [helper, ide, web]
 
 Automatically install [code-server](https://github.com/coder/code-server) in a workspace, create an app to access it via the dashboard, install extensions, and pre-configure editor settings.
 
-```hcl
+```tf
 module "code-server" {
   source = "registry.coder.com/modules/code-server/coder"
   version = "1.0.0"
@@ -25,7 +25,7 @@ module "code-server" {
 
 ### Pin Versions
 
-```hcl
+```tf
 module "code-server" {
   source          = "registry.coder.com/modules/code-server/coder"
   version         = "1.0.0"
@@ -38,7 +38,7 @@ module "code-server" {
 
 Install the Dracula theme from [OpenVSX](https://open-vsx.org/):
 
-```hcl
+```tf
 module "code-server" {
   source = "registry.coder.com/modules/code-server/coder"
   version = "1.0.0"
@@ -55,7 +55,7 @@ Enter the `<author>.<name>` into the extensions array and code-server will autom
 
 Configure VS Code's [settings.json](https://code.visualstudio.com/docs/getstarted/settings#_settingsjson) file:
 
-```hcl
+```tf
 module "settings" {
   source = "registry.coder.com/modules/code-server/coder"
   version = "1.0.0"
@@ -71,7 +71,7 @@ module "settings" {
 
 Just run code-server in the background, don't fetch it from GitHub:
 
-```hcl
+```tf
 module "settings" {
   source = "registry.coder.com/modules/code-server/coder"
   version = "1.0.0"
@@ -84,7 +84,7 @@ module "settings" {
 
 Just run code-server in the background, don't fetch it from GitHub:
 
-```hcl
+```tf
 module "settings" {
   source = "registry.coder.com/modules/code-server/coder"
   version = "1.0.0"

--- a/coder-login/README.md
+++ b/coder-login/README.md
@@ -11,7 +11,7 @@ tags: [helper]
 
 Automatically logs the user into Coder when creating their workspace.
 
-```hcl
+```tf
 module "coder-login" {
   source   = "registry.coder.com/modules/coder-login/coder"
   version  = "1.0.0"

--- a/dotfiles/README.md
+++ b/dotfiles/README.md
@@ -11,7 +11,7 @@ tags: [helper]
 
 Allow developers to optionally bring their own [dotfiles repository](https://dotfiles.github.io)! Under the hood, this module uses the [coder dotfiles](https://coder.com/docs/v2/latest/dotfiles) command.
 
-```hcl
+```tf
 module "dotfiles" {
   source = "registry.coder.com/modules/dotfiles/coder"
   version = "1.0.0"

--- a/dotfiles/README.md
+++ b/dotfiles/README.md
@@ -13,8 +13,8 @@ Allow developers to optionally bring their own [dotfiles repository](https://dot
 
 ```tf
 module "dotfiles" {
-  source = "registry.coder.com/modules/dotfiles/coder"
-  version = "1.0.0"
+  source   = "registry.coder.com/modules/dotfiles/coder"
+  version  = "1.0.0"
   agent_id = coder_agent.example.id
 }
 ```

--- a/exoscale-instance-type/README.md
+++ b/exoscale-instance-type/README.md
@@ -14,7 +14,7 @@ their desired virtuell machine for the workspace.
 
 Customize the preselected parameter value:
 
-```hcl
+```tf
 module "exoscale-instance-type" {
   source = "registry.coder.com/modules/exoscale-instance-type/coder"
   version = "1.0.0"
@@ -42,7 +42,7 @@ resource "coder_metadata" "workspace_info" {
 
 Change the display name a type using the corresponding maps:
 
-```hcl
+```tf
 module "exoscale-instance-type" {
   source = "registry.coder.com/modules/exoscale-instance-type/coder"
   version = "1.0.0"
@@ -74,7 +74,7 @@ resource "coder_metadata" "workspace_info" {
 
 Show only gpu1 types
 
-```hcl
+```tf
 module "exoscale-instance-type" {
   source        = "registry.coder.com/modules/exoscale-instance-type/coder"
   version       = "1.0.0"

--- a/exoscale-instance-type/README.md
+++ b/exoscale-instance-type/README.md
@@ -23,7 +23,7 @@ module "exoscale-instance-type" {
 
 resource "exoscale_compute_instance" "instance" {
   type        = module.exoscale-instance-type.value
-  ...
+  # ...
 }
 
 resource "coder_metadata" "workspace_info" {
@@ -57,7 +57,7 @@ module "exoscale-instance-type" {
 
 resource "exoscale_compute_instance" "instance" {
   type        = module.exoscale-instance-type.value
-  ...
+  # ...
 }
 
 resource "coder_metadata" "workspace_info" {
@@ -94,7 +94,7 @@ module "exoscale-instance-type" {
 
 resource "exoscale_compute_instance" "instance" {
   type        = module.exoscale-instance-type.value
-  ...
+  # ...
 }
 
 resource "coder_metadata" "workspace_info" {

--- a/exoscale-instance-type/README.md
+++ b/exoscale-instance-type/README.md
@@ -16,13 +16,13 @@ Customize the preselected parameter value:
 
 ```tf
 module "exoscale-instance-type" {
-  source = "registry.coder.com/modules/exoscale-instance-type/coder"
+  source  = "registry.coder.com/modules/exoscale-instance-type/coder"
   version = "1.0.0"
   default = "standard.medium"
 }
 
 resource "exoscale_compute_instance" "instance" {
-  type        = module.exoscale-instance-type.value
+  type = module.exoscale-instance-type.value
   # ...
 }
 
@@ -44,19 +44,19 @@ Change the display name a type using the corresponding maps:
 
 ```tf
 module "exoscale-instance-type" {
-  source = "registry.coder.com/modules/exoscale-instance-type/coder"
+  source  = "registry.coder.com/modules/exoscale-instance-type/coder"
   version = "1.0.0"
   default = "standard.medium"
   custom_names = {
-    "standard.medium": "Mittlere Instanz" # German translation
+    "standard.medium" : "Mittlere Instanz" # German translation
   }
   custom_descriptions = {
-    "standard.medium": "4 GB Arbeitsspeicher, 2 Kerne, 10 - 400 GB Festplatte" # German translation
+    "standard.medium" : "4 GB Arbeitsspeicher, 2 Kerne, 10 - 400 GB Festplatte" # German translation
   }
 }
 
 resource "exoscale_compute_instance" "instance" {
-  type        = module.exoscale-instance-type.value
+  type = module.exoscale-instance-type.value
   # ...
 }
 
@@ -80,7 +80,7 @@ module "exoscale-instance-type" {
   version       = "1.0.0"
   default       = "gpu.large"
   type_category = ["gpu"]
-  exclude       = [
+  exclude = [
     "gpu2.small",
     "gpu2.medium",
     "gpu2.large",
@@ -93,7 +93,7 @@ module "exoscale-instance-type" {
 }
 
 resource "exoscale_compute_instance" "instance" {
-  type        = module.exoscale-instance-type.value
+  type = module.exoscale-instance-type.value
   # ...
 }
 

--- a/exoscale-zone/README.md
+++ b/exoscale-zone/README.md
@@ -14,7 +14,7 @@ the zone closest to them.
 
 Customize the preselected parameter value:
 
-```hcl
+```tf
 module "exoscale-zone" {
   source = "registry.coder.com/modules/exoscale-zone/coder"
   version = "1.0.0"
@@ -41,7 +41,7 @@ resource "exoscale_compute_instance" "instance" {
 
 Change the display name and icon for a zone using the corresponding maps:
 
-```hcl
+```tf
 module "exoscale-zone" {
   source = "registry.coder.com/modules/exoscale-zone/coder"
   version = "1.0.0"
@@ -71,7 +71,7 @@ resource "exoscale_compute_instance" "instance" {
 
 Hide the Switzerland zones Geneva and Zurich
 
-```hcl
+```tf
 module "exoscale-zone" {
   source = "registry.coder.com/modules/exoscale-zone/coder"
   version = "1.0.0"

--- a/exoscale-zone/README.md
+++ b/exoscale-zone/README.md
@@ -16,7 +16,7 @@ Customize the preselected parameter value:
 
 ```tf
 module "exoscale-zone" {
-  source = "registry.coder.com/modules/exoscale-zone/coder"
+  source  = "registry.coder.com/modules/exoscale-zone/coder"
   version = "1.0.0"
   default = "ch-dk-2"
 }
@@ -28,7 +28,7 @@ data "exoscale_compute_template" "my_template" {
 }
 
 resource "exoscale_compute_instance" "instance" {
-  zone    = module.exoscale-zone.value
+  zone = module.exoscale-zone.value
   # ...
 }
 ```
@@ -43,14 +43,14 @@ Change the display name and icon for a zone using the corresponding maps:
 
 ```tf
 module "exoscale-zone" {
-  source = "registry.coder.com/modules/exoscale-zone/coder"
+  source  = "registry.coder.com/modules/exoscale-zone/coder"
   version = "1.0.0"
   default = "at-vie-1"
   custom_names = {
-    "at-vie-1": "Home Vienna"
+    "at-vie-1" : "Home Vienna"
   }
   custom_icons = {
-    "at-vie-1": "/emojis/1f3e0.png"
+    "at-vie-1" : "/emojis/1f3e0.png"
   }
 }
 
@@ -60,7 +60,7 @@ data "exoscale_compute_template" "my_template" {
 }
 
 resource "exoscale_compute_instance" "instance" {
-  zone    = module.exoscale-zone.value
+  zone = module.exoscale-zone.value
   # ...
 }
 ```
@@ -73,9 +73,9 @@ Hide the Switzerland zones Geneva and Zurich
 
 ```tf
 module "exoscale-zone" {
-  source = "registry.coder.com/modules/exoscale-zone/coder"
+  source  = "registry.coder.com/modules/exoscale-zone/coder"
   version = "1.0.0"
-  exclude = [ "ch-gva-2", "ch-dk-2" ]
+  exclude = ["ch-gva-2", "ch-dk-2"]
 }
 
 data "exoscale_compute_template" "my_template" {
@@ -84,7 +84,7 @@ data "exoscale_compute_template" "my_template" {
 }
 
 resource "exoscale_compute_instance" "instance" {
-  zone    = module.exoscale-zone.value
+  zone = module.exoscale-zone.value
   # ...
 }
 ```

--- a/exoscale-zone/README.md
+++ b/exoscale-zone/README.md
@@ -29,7 +29,7 @@ data "exoscale_compute_template" "my_template" {
 
 resource "exoscale_compute_instance" "instance" {
   zone    = module.exoscale-zone.value
-  ....
+  # ...
 }
 ```
 
@@ -61,7 +61,7 @@ data "exoscale_compute_template" "my_template" {
 
 resource "exoscale_compute_instance" "instance" {
   zone    = module.exoscale-zone.value
-  ....
+  # ...
 }
 ```
 
@@ -85,7 +85,7 @@ data "exoscale_compute_template" "my_template" {
 
 resource "exoscale_compute_instance" "instance" {
   zone    = module.exoscale-zone.value
-  ....
+  # ...
 }
 ```
 

--- a/filebrowser/README.md
+++ b/filebrowser/README.md
@@ -13,8 +13,8 @@ A file browser for your workspace.
 
 ```tf
 module "filebrowser" {
-  source = "registry.coder.com/modules/filebrowser/coder"
-  version = "1.0.0"
+  source   = "registry.coder.com/modules/filebrowser/coder"
+  version  = "1.0.0"
   agent_id = coder_agent.example.id
 }
 ```
@@ -27,10 +27,10 @@ module "filebrowser" {
 
 ```tf
 module "filebrowser" {
-  source = "registry.coder.com/modules/filebrowser/coder"
-  version = "1.0.0"
+  source   = "registry.coder.com/modules/filebrowser/coder"
+  version  = "1.0.0"
   agent_id = coder_agent.example.id
-  folder = "/home/coder/project"
+  folder   = "/home/coder/project"
 }
 ```
 
@@ -38,9 +38,9 @@ module "filebrowser" {
 
 ```tf
 module "filebrowser" {
-  source = "registry.coder.com/modules/filebrowser/coder"
-  version = "1.0.0"
-  agent_id = coder_agent.example.id
+  source        = "registry.coder.com/modules/filebrowser/coder"
+  version       = "1.0.0"
+  agent_id      = coder_agent.example.id
   database_path = ".config/filebrowser.db"
 }
 ```

--- a/filebrowser/README.md
+++ b/filebrowser/README.md
@@ -11,7 +11,7 @@ tags: [helper, filebrowser]
 
 A file browser for your workspace.
 
-```hcl
+```tf
 module "filebrowser" {
   source = "registry.coder.com/modules/filebrowser/coder"
   version = "1.0.0"
@@ -25,7 +25,7 @@ module "filebrowser" {
 
 ### Serve a specific directory
 
-```hcl
+```tf
 module "filebrowser" {
   source = "registry.coder.com/modules/filebrowser/coder"
   version = "1.0.0"
@@ -36,7 +36,7 @@ module "filebrowser" {
 
 ### Specify location of `filebrowser.db`
 
-```hcl
+```tf
 module "filebrowser" {
   source = "registry.coder.com/modules/filebrowser/coder"
   version = "1.0.0"

--- a/fly-region/README.md
+++ b/fly-region/README.md
@@ -13,7 +13,7 @@ This module adds Fly.io regions to your Coder template. Regions can be whitelist
 
 We can use the simplest format here, only adding a default selection as the `atl` region.
 
-```hcl
+```tf
 module "fly-region" {
   source = "registry.coder.com/modules/fly-region/coder"
   version = "1.0.0"
@@ -29,7 +29,7 @@ module "fly-region" {
 
 The regions argument can be used to display only the desired regions in the Coder parameter.
 
-```hcl
+```tf
 module "fly-region" {
   source = "registry.coder.com/modules/fly-region/coder"
   version = "1.0.0"
@@ -44,7 +44,7 @@ module "fly-region" {
 
 Set custom icons and names with their respective maps.
 
-```hcl
+```tf
 module "fly-region" {
   source = "registry.coder.com/modules/fly-region/coder"
   version = "1.0.0"

--- a/fly-region/README.md
+++ b/fly-region/README.md
@@ -15,7 +15,7 @@ We can use the simplest format here, only adding a default selection as the `atl
 
 ```tf
 module "fly-region" {
-  source = "registry.coder.com/modules/fly-region/coder"
+  source  = "registry.coder.com/modules/fly-region/coder"
   version = "1.0.0"
   default = "atl"
 }
@@ -31,7 +31,7 @@ The regions argument can be used to display only the desired regions in the Code
 
 ```tf
 module "fly-region" {
-  source = "registry.coder.com/modules/fly-region/coder"
+  source  = "registry.coder.com/modules/fly-region/coder"
   version = "1.0.0"
   default = "ams"
   regions = ["ams", "arn", "atl"]
@@ -46,14 +46,14 @@ Set custom icons and names with their respective maps.
 
 ```tf
 module "fly-region" {
-  source = "registry.coder.com/modules/fly-region/coder"
+  source  = "registry.coder.com/modules/fly-region/coder"
   version = "1.0.0"
   default = "ams"
   custom_icons = {
-      "ams" = "/emojis/1f90e.png"
+    "ams" = "/emojis/1f90e.png"
   }
   custom_names = {
-      "ams" = "We love the Netherlands!"
+    "ams" = "We love the Netherlands!"
   }
 }
 ```

--- a/gcp-region/README.md
+++ b/gcp-region/README.md
@@ -11,7 +11,7 @@ tags: [gcp, regions, parameter, helper]
 
 This module adds Google Cloud Platform regions to your Coder template.
 
-```hcl
+```tf
 module "gcp_region" {
   source  = "registry.coder.com/modules/gcp-region/coder"
   version = "1.0.0"
@@ -31,7 +31,7 @@ resource "google_compute_instance" "example" {
 
 Note: setting `gpu_only = true` and using a default region without GPU support, the default will be set to `null`.
 
-```hcl
+```tf
 module "gcp_region" {
   source   = "registry.coder.com/modules/gcp-region/coder"
   version  = "1.0.0"
@@ -47,7 +47,7 @@ resource "google_compute_instance" "example" {
 
 ### Add all zones in the Europe West region
 
-```hcl
+```tf
 module "gcp_region" {
   source                 = "registry.coder.com/modules/gcp-region/coder"
   version                = "1.0.0"
@@ -62,7 +62,7 @@ resource "google_compute_instance" "example" {
 
 ### Add a single zone from each region in US and Europe that laos has GPUs
 
-```hcl
+```tf
 module "gcp_region" {
   source                 = "registry.coder.com/modules/gcp-region/coder"
   version                = "1.0.0"

--- a/git-clone/README.md
+++ b/git-clone/README.md
@@ -11,7 +11,7 @@ tags: [git, helper]
 
 This module allows you to automatically clone a repository by URL and skip if it exists in the base directory provided.
 
-```hcl
+```tf
 module "git-clone" {
   source   = "registry.coder.com/modules/git-clone/coder"
   version  = "1.0.0"
@@ -22,7 +22,7 @@ module "git-clone" {
 
 To use with [Git Authentication](https://coder.com/docs/v2/latest/admin/git-providers), add the provider by ID to your template:
 
-```hcl
+```tf
 data "coder_git_auth" "github" {
   id = "github"
 }
@@ -32,7 +32,7 @@ data "coder_git_auth" "github" {
 
 ### Custom Path
 
-```hcl
+```tf
 module "git-clone" {
   source   = "registry.coder.com/modules/git-clone/coder"
   version  = "1.0.0"

--- a/git-commit-signing/README.md
+++ b/git-commit-signing/README.md
@@ -16,7 +16,7 @@ Please observe that using the SSH key that's part of your Coder account for comm
 
 This module has a chance of conflicting with the user's dotfiles / the personalize module if one of those has configuration directives that overwrite this module's / each other's git configuration.
 
-```hcl
+```tf
 module "git-commit-signing" {
   source = "registry.coder.com/modules/git-commit-signing/coder"
   version = "1.0.0"

--- a/git-commit-signing/README.md
+++ b/git-commit-signing/README.md
@@ -18,8 +18,8 @@ This module has a chance of conflicting with the user's dotfiles / the personali
 
 ```tf
 module "git-commit-signing" {
-  source = "registry.coder.com/modules/git-commit-signing/coder"
-  version = "1.0.0"
+  source   = "registry.coder.com/modules/git-commit-signing/coder"
+  version  = "1.0.0"
   agent_id = coder_agent.example.id
 }
 ```

--- a/git-config/README.md
+++ b/git-config/README.md
@@ -13,8 +13,8 @@ Runs a script that updates git credentials in the workspace to match the user's 
 
 ```tf
 module "git-config" {
-  source = "registry.coder.com/modules/git-config/coder"
-  version = "1.0.0"
+  source   = "registry.coder.com/modules/git-config/coder"
+  version  = "1.0.0"
   agent_id = coder_agent.example.id
 }
 ```
@@ -27,9 +27,9 @@ TODO: Add screenshot
 
 ```tf
 module "git-config" {
-  source = "registry.coder.com/modules/git-config/coder"
-  version = "1.0.0"
-  agent_id = coder_agent.example.id
+  source             = "registry.coder.com/modules/git-config/coder"
+  version            = "1.0.0"
+  agent_id           = coder_agent.example.id
   allow_email_change = true
 }
 ```
@@ -40,11 +40,11 @@ TODO: Add screenshot
 
 ```tf
 module "git-config" {
-  source = "registry.coder.com/modules/git-config/coder"
-  version = "1.0.0"
-  agent_id = coder_agent.example.id
+  source                = "registry.coder.com/modules/git-config/coder"
+  version               = "1.0.0"
+  agent_id              = coder_agent.example.id
   allow_username_change = false
-  allow_email_change = false
+  allow_email_change    = false
 }
 ```
 

--- a/git-config/README.md
+++ b/git-config/README.md
@@ -11,7 +11,7 @@ tags: [helper, git]
 
 Runs a script that updates git credentials in the workspace to match the user's Coder credentials, optionally allowing to the developer to override the defaults.
 
-```hcl
+```tf
 module "git-config" {
   source = "registry.coder.com/modules/git-config/coder"
   version = "1.0.0"
@@ -25,7 +25,7 @@ TODO: Add screenshot
 
 ### Allow users to override both username and email
 
-```hcl
+```tf
 module "git-config" {
   source = "registry.coder.com/modules/git-config/coder"
   version = "1.0.0"
@@ -38,7 +38,7 @@ TODO: Add screenshot
 
 ## Disallowing users from overriding both username and email
 
-```hcl
+```tf
 module "git-config" {
   source = "registry.coder.com/modules/git-config/coder"
   version = "1.0.0"

--- a/jetbrains-gateway/README.md
+++ b/jetbrains-gateway/README.md
@@ -11,7 +11,7 @@ tags: [ide, jetbrains, helper, parameter]
 
 This module adds a JetBrains Gateway Button to open any workspace with a single click.
 
-```hcl
+```tf
 module "jetbrains_gateway" {
   source         = "registry.coder.com/modules/jetbrains-gateway/coder"
   version        = "1.0.0"
@@ -28,7 +28,7 @@ module "jetbrains_gateway" {
 
 ### Add GoLand and WebStorm with the default set to GoLand
 
-```hcl
+```tf
 module "jetbrains_gateway" {
   source          = "registry.coder.com/modules/jetbrains-gateway/coder"
   version         = "1.0.0"

--- a/jetbrains-gateway/README.md
+++ b/jetbrains-gateway/README.md
@@ -30,12 +30,12 @@ module "jetbrains_gateway" {
 
 ```tf
 module "jetbrains_gateway" {
-  source          = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version         = "1.0.0"
-  agent_id        = coder_agent.example.id
-  folder          = "/home/coder/example"
-  jetbrains_ides  = ["GO", "WS"]
-  default         = "GO"
+  source         = "registry.coder.com/modules/jetbrains-gateway/coder"
+  version        = "1.0.0"
+  agent_id       = coder_agent.example.id
+  folder         = "/home/coder/example"
+  jetbrains_ides = ["GO", "WS"]
+  default        = "GO"
 }
 ```
 

--- a/jfrog-oauth/README.md
+++ b/jfrog-oauth/README.md
@@ -14,7 +14,7 @@ Install the JF CLI and authenticate package managers with Artifactory using OAut
 
 ![JFrog OAuth](../.images/jfrog-oauth.png)
 
-```hcl
+```tf
 module "jfrog" {
   source = "registry.coder.com/modules/jfrog-oauth/coder"
   version = "1.0.0"
@@ -40,7 +40,7 @@ This module is usable by JFrog self-hosted (on-premises) Artifactory as it requi
 
 Configure the Python pip package manager to fetch packages from Artifactory while mapping the Coder email to the Artifactory username.
 
-```hcl
+```tf
 module "jfrog" {
   source = "registry.coder.com/modules/jfrog-oauth/coder"
   version = "1.0.0"
@@ -67,7 +67,7 @@ pip install requests
 
 The [JFrog extension](https://open-vsx.org/extension/JFrog/jfrog-vscode-extension) for VS Code allows you to interact with Artifactory from within the IDE.
 
-```hcl
+```tf
 module "jfrog" {
   source = "registry.coder.com/modules/jfrog-oauth/coder"
   version = "1.0.0"
@@ -87,7 +87,7 @@ module "jfrog" {
 
 JFrog Access token is also available as a terraform output. You can use it in other terraform resources. For example, you can use it to configure an [Artifactory docker registry](https://jfrog.com/help/r/jfrog-artifactory-documentation/docker-registry) with the [docker terraform provider](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs).
 
-```hcl
+```tf
 provider "docker" {
   ...
   registry_auth {

--- a/jfrog-oauth/README.md
+++ b/jfrog-oauth/README.md
@@ -91,7 +91,7 @@ JFrog Access token is also available as a terraform output. You can use it in ot
 provider "docker" {
   # ...
   registry_auth {
-    address = "https://example.jfrog.io/artifactory/api/docker/REPO-KEY"
+    address  = "https://example.jfrog.io/artifactory/api/docker/REPO-KEY"
     username = module.jfrog.username
     password = module.jfrog.access_token
   }

--- a/jfrog-oauth/README.md
+++ b/jfrog-oauth/README.md
@@ -89,7 +89,7 @@ JFrog Access token is also available as a terraform output. You can use it in ot
 
 ```tf
 provider "docker" {
-  ...
+  # ...
   registry_auth {
     address = "https://example.jfrog.io/artifactory/api/docker/REPO-KEY"
     username = module.jfrog.username

--- a/jfrog-oauth/README.md
+++ b/jfrog-oauth/README.md
@@ -16,15 +16,15 @@ Install the JF CLI and authenticate package managers with Artifactory using OAut
 
 ```tf
 module "jfrog" {
-  source = "registry.coder.com/modules/jfrog-oauth/coder"
-  version = "1.0.0"
-  agent_id = coder_agent.example.id
-  jfrog_url = "https://example.jfrog.io"
+  source         = "registry.coder.com/modules/jfrog-oauth/coder"
+  version        = "1.0.0"
+  agent_id       = coder_agent.example.id
+  jfrog_url      = "https://example.jfrog.io"
   username_field = "username" # If you are using GitHub to login to both Coder and Artifactory, use username_field = "username"
   package_managers = {
-    "npm": "npm",
-    "go": "go",
-    "pypi": "pypi"
+    "npm" : "npm",
+    "go" : "go",
+    "pypi" : "pypi"
   }
 }
 ```
@@ -42,13 +42,13 @@ Configure the Python pip package manager to fetch packages from Artifactory whil
 
 ```tf
 module "jfrog" {
-  source = "registry.coder.com/modules/jfrog-oauth/coder"
-  version = "1.0.0"
-  agent_id = coder_agent.example.id
-  jfrog_url = "https://example.jfrog.io"
+  source         = "registry.coder.com/modules/jfrog-oauth/coder"
+  version        = "1.0.0"
+  agent_id       = coder_agent.example.id
+  jfrog_url      = "https://example.jfrog.io"
   username_field = "email"
   package_managers = {
-    "pypi": "pypi"
+    "pypi" : "pypi"
   }
 }
 ```
@@ -69,16 +69,16 @@ The [JFrog extension](https://open-vsx.org/extension/JFrog/jfrog-vscode-extensio
 
 ```tf
 module "jfrog" {
-  source = "registry.coder.com/modules/jfrog-oauth/coder"
-  version = "1.0.0"
-  agent_id = coder_agent.example.id
-  jfrog_url = "https://example.jfrog.io"
-  username_field = "username" # If you are using GitHub to login to both Coder and Artifactory, use username_field = "username"
-  configure_code_server = true # Add JFrog extension configuration for code-server
+  source                = "registry.coder.com/modules/jfrog-oauth/coder"
+  version               = "1.0.0"
+  agent_id              = coder_agent.example.id
+  jfrog_url             = "https://example.jfrog.io"
+  username_field        = "username" # If you are using GitHub to login to both Coder and Artifactory, use username_field = "username"
+  configure_code_server = true       # Add JFrog extension configuration for code-server
   package_managers = {
-    "npm": "npm",
-    "go": "go",
-    "pypi": "pypi"
+    "npm" : "npm",
+    "go" : "go",
+    "pypi" : "pypi"
   }
 }
 ```

--- a/jfrog-token/README.md
+++ b/jfrog-token/README.md
@@ -12,7 +12,7 @@ tags: [integration, jfrog]
 
 Install the JF CLI and authenticate package managers with Artifactory using Artifactory terraform provider.
 
-```hcl
+```tf
 module "jfrog" {
   source = "registry.coder.com/modules/jfrog-token/coder"
   version = "1.0.0"
@@ -38,7 +38,7 @@ For detailed instructions, please see this [guide](https://coder.com/docs/v2/lat
 
 ### Configure npm, go, and pypi to use Artifactory local repositories
 
-```hcl
+```tf
 module "jfrog" {
   source = "registry.coder.com/modules/jfrog-token/coder"
   version = "1.0.0"
@@ -71,7 +71,7 @@ pip install requests
 
 The [JFrog extension](https://open-vsx.org/extension/JFrog/jfrog-vscode-extension) for VS Code allows you to interact with Artifactory from within the IDE.
 
-```hcl
+```tf
 module "jfrog" {
   source = "registry.coder.com/modules/jfrog-token/coder"
   version = "1.0.0"
@@ -91,7 +91,7 @@ module "jfrog" {
 
 JFrog Access token is also available as a terraform output. You can use it in other terraform resources. For example, you can use it to configure an [Artifactory docker registry](https://jfrog.com/help/r/jfrog-artifactory-documentation/docker-registry) with the [docker terraform provider](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs).
 
-```hcl
+```tf
 
 provider "docker" {
   ...

--- a/jfrog-token/README.md
+++ b/jfrog-token/README.md
@@ -14,15 +14,15 @@ Install the JF CLI and authenticate package managers with Artifactory using Arti
 
 ```tf
 module "jfrog" {
-  source = "registry.coder.com/modules/jfrog-token/coder"
-  version = "1.0.0"
-  agent_id = coder_agent.example.id
-  jfrog_url = "https://XXXX.jfrog.io"
+  source                   = "registry.coder.com/modules/jfrog-token/coder"
+  version                  = "1.0.0"
+  agent_id                 = coder_agent.example.id
+  jfrog_url                = "https://XXXX.jfrog.io"
   artifactory_access_token = var.artifactory_access_token
   package_managers = {
-    "npm": "npm",
-    "go": "go",
-    "pypi": "pypi"
+    "npm" : "npm",
+    "go" : "go",
+    "pypi" : "pypi"
   }
 }
 ```
@@ -40,15 +40,15 @@ For detailed instructions, please see this [guide](https://coder.com/docs/v2/lat
 
 ```tf
 module "jfrog" {
-  source = "registry.coder.com/modules/jfrog-token/coder"
-  version = "1.0.0"
-  agent_id = coder_agent.example.id
-  jfrog_url = "https://YYYY.jfrog.io"
+  source                   = "registry.coder.com/modules/jfrog-token/coder"
+  version                  = "1.0.0"
+  agent_id                 = coder_agent.example.id
+  jfrog_url                = "https://YYYY.jfrog.io"
   artifactory_access_token = var.artifactory_access_token # An admin access token
   package_managers = {
-    "npm": "npm-local",
-    "go": "go-local",
-    "pypi": "pypi-local"
+    "npm" : "npm-local",
+    "go" : "go-local",
+    "pypi" : "pypi-local"
   }
 }
 ```
@@ -73,16 +73,16 @@ The [JFrog extension](https://open-vsx.org/extension/JFrog/jfrog-vscode-extensio
 
 ```tf
 module "jfrog" {
-  source = "registry.coder.com/modules/jfrog-token/coder"
-  version = "1.0.0"
-  agent_id = coder_agent.example.id
-  jfrog_url = "https://XXXX.jfrog.io"
+  source                   = "registry.coder.com/modules/jfrog-token/coder"
+  version                  = "1.0.0"
+  agent_id                 = coder_agent.example.id
+  jfrog_url                = "https://XXXX.jfrog.io"
   artifactory_access_token = var.artifactory_access_token
-  configure_code_server = true # Add JFrog extension configuration for code-server
+  configure_code_server    = true # Add JFrog extension configuration for code-server
   package_managers = {
-    "npm": "npm",
-    "go": "go",
-    "pypi": "pypi"
+    "npm" : "npm",
+    "go" : "go",
+    "pypi" : "pypi"
   }
 }
 ```

--- a/jfrog-token/README.md
+++ b/jfrog-token/README.md
@@ -96,7 +96,7 @@ JFrog Access token is also available as a terraform output. You can use it in ot
 provider "docker" {
   # ...
   registry_auth {
-    address = "https://YYYY.jfrog.io/artifactory/api/docker/REPO-KEY"
+    address  = "https://YYYY.jfrog.io/artifactory/api/docker/REPO-KEY"
     username = module.jfrog.username
     password = module.jfrog.access_token
   }

--- a/jfrog-token/README.md
+++ b/jfrog-token/README.md
@@ -94,7 +94,7 @@ JFrog Access token is also available as a terraform output. You can use it in ot
 ```tf
 
 provider "docker" {
-  ...
+  # ...
   registry_auth {
     address = "https://YYYY.jfrog.io/artifactory/api/docker/REPO-KEY"
     username = module.jfrog.username

--- a/jupyter-notebook/README.md
+++ b/jupyter-notebook/README.md
@@ -13,7 +13,7 @@ A module that adds Jupyter Notebook in your Coder template.
 
 ![Jupyter Notebook](../.images/jupyter-notebook.png)
 
-```hcl
+```tf
 module "jupyter-notebook" {
   source = "registry.coder.com/modules/jupyter-notebook/coder"
   version = "1.0.0"

--- a/jupyter-notebook/README.md
+++ b/jupyter-notebook/README.md
@@ -15,8 +15,8 @@ A module that adds Jupyter Notebook in your Coder template.
 
 ```tf
 module "jupyter-notebook" {
-  source = "registry.coder.com/modules/jupyter-notebook/coder"
-  version = "1.0.0"
+  source   = "registry.coder.com/modules/jupyter-notebook/coder"
+  version  = "1.0.0"
   agent_id = coder_agent.example.id
 }
 ```

--- a/jupyterlab/README.md
+++ b/jupyterlab/README.md
@@ -13,7 +13,7 @@ A module that adds JupyterLab in your Coder template.
 
 ![JupyterLab](../.images/jupyterlab.png)
 
-```hcl
+```tf
 module "jupyterlab" {
   source = "registry.coder.com/modules/jupyterlab/coder"
   version = "1.0.0"

--- a/jupyterlab/README.md
+++ b/jupyterlab/README.md
@@ -15,8 +15,8 @@ A module that adds JupyterLab in your Coder template.
 
 ```tf
 module "jupyterlab" {
-  source = "registry.coder.com/modules/jupyterlab/coder"
-  version = "1.0.0"
+  source   = "registry.coder.com/modules/jupyterlab/coder"
+  version  = "1.0.0"
   agent_id = coder_agent.example.id
 }
 ```

--- a/package.json
+++ b/package.json
@@ -2,17 +2,24 @@
   "name": "modules",
   "scripts": {
     "test": "bun test",
-    "fmt": "bun x prettier --plugin prettier-plugin-sh -w **/*.sh .sample/run.sh new.sh **/*.ts **/*.md *.md && terraform fmt **/*.tf .sample/main.tf",
-    "fmt:ci": "bun x prettier --plugin prettier-plugin-sh --check **/*.sh .sample/run.sh new.sh **/*.ts **/*.md *.md && terraform fmt -check **/*.tf .sample/main.tf",
+    "fmt": "bun x prettier -w **/*.sh .sample/run.sh new.sh **/*.ts **/*.md *.md && terraform fmt **/*.tf .sample/main.tf",
+    "fmt:ci": "bun x prettier --check **/*.sh .sample/run.sh new.sh **/*.ts **/*.md *.md && terraform fmt -check **/*.tf .sample/main.tf",
     "lint": "bun run lint.ts"
   },
   "devDependencies": {
     "bun-types": "^1.0.18",
     "gray-matter": "^4.0.3",
     "marked": "^11.1.0",
-    "prettier-plugin-sh": "^0.13.1"
+    "prettier-plugin-sh": "^0.13.1",
+    "prettier-plugin-terraform-formatter": "^1.2.1"
   },
   "peerDependencies": {
     "typescript": "^5.3.3"
+  },
+  "prettier": {
+    "plugins": [
+      "prettier-plugin-sh",
+      "prettier-plugin-terraform-formatter"
+    ]
   }
 }

--- a/personalize/README.md
+++ b/personalize/README.md
@@ -13,8 +13,8 @@ Run a script on workspace start that allows developers to run custom commands to
 
 ```tf
 module "personalize" {
-  source = "registry.coder.com/modules/personalize/coder"
-  version = "1.0.0"
+  source   = "registry.coder.com/modules/personalize/coder"
+  version  = "1.0.0"
   agent_id = coder_agent.example.id
 }
 ```

--- a/personalize/README.md
+++ b/personalize/README.md
@@ -11,7 +11,7 @@ tags: [helper]
 
 Run a script on workspace start that allows developers to run custom commands to personalize their workspace.
 
-```hcl
+```tf
 module "personalize" {
   source = "registry.coder.com/modules/personalize/coder"
   version = "1.0.0"

--- a/slackme/README.md
+++ b/slackme/README.md
@@ -54,7 +54,7 @@ slackme npm run long-build
 
 3. Restart your Coder deployment. Any Template can now import the Slack Me module, and `slackme` will be available on the `$PATH`:
 
-   ```hcl
+   ```tf
    module "slackme" {
      source = "registry.coder.com/modules/slackme/coder"
      version = "1.0.0"
@@ -70,7 +70,7 @@ slackme npm run long-build
 - `$COMMAND` is replaced with the command the user executed.
 - `$DURATION` is replaced with a human-readable duration the command took to execute.
 
-```hcl
+```tf
 module "slackme" {
   source = "registry.coder.com/modules/slackme/coder"
   version = "1.0.0"

--- a/slackme/README.md
+++ b/slackme/README.md
@@ -56,9 +56,9 @@ slackme npm run long-build
 
    ```tf
    module "slackme" {
-     source = "registry.coder.com/modules/slackme/coder"
-     version = "1.0.0"
-     agent_id = coder_agent.example.id
+     source           = "registry.coder.com/modules/slackme/coder"
+     version          = "1.0.0"
+     agent_id         = coder_agent.example.id
      auth_provider_id = "slack"
    }
    ```
@@ -72,11 +72,11 @@ slackme npm run long-build
 
 ```tf
 module "slackme" {
-  source = "registry.coder.com/modules/slackme/coder"
-  version = "1.0.0"
-  agent_id = coder_agent.example.id
+  source           = "registry.coder.com/modules/slackme/coder"
+  version          = "1.0.0"
+  agent_id         = coder_agent.example.id
   auth_provider_id = "slack"
-  slack_message = <<EOF
+  slack_message    = <<EOF
 👋 Hey there from Coder! $COMMAND took $DURATION to execute!
 EOF
 }

--- a/vault-github/README.md
+++ b/vault-github/README.md
@@ -11,7 +11,7 @@ tags: [helper, integration, vault, github]
 
 This module lets you authenticate with [Hashicorp Vault](https://www.vaultproject.io/) in your Coder workspaces using [external auth](https://coder.com/docs/v2/latest/admin/external-auth) for GitHub.
 
-```hcl
+```tf
 module "vault" {
   source     = "registry.coder.com/modules/vault-github/coder"
   version    = "1.0.0"
@@ -42,7 +42,7 @@ To configure the Vault module, you must set up a Vault GitHub auth method. See t
 
 ### Configure Vault integration with a different Coder GitHub external auth ID (i.e., not the default `github`)
 
-```hcl
+```tf
 module "vault" {
   source               = "registry.coder.com/modules/vault-github/coder"
   version              = "1.0.0"
@@ -54,7 +54,7 @@ module "vault" {
 
 ### Configure Vault integration with a different Coder GitHub external auth ID and a different Vault GitHub auth path
 
-```hcl
+```tf
 module "vault" {
   source                 = "registry.coder.com/modules/vault-github/coder"
   version                = "1.0.0"
@@ -67,7 +67,7 @@ module "vault" {
 
 ### Configure Vault integration and install a specific version of the Vault CLI
 
-```hcl
+```tf
 module "vault" {
   source            = "registry.coder.com/modules/vault-github/coder"
   version           = "1.0.0"

--- a/vscode-desktop/README.md
+++ b/vscode-desktop/README.md
@@ -13,7 +13,7 @@ Add a button to open any workspace with a single click.
 
 Uses the [Coder Remote VS Code Extension](https://github.com/coder/vscode-coder).
 
-```hcl
+```tf
 module "vscode" {
   source = "registry.coder.com/modules/vscode-desktop/coder"
   version = "1.0.0"
@@ -25,7 +25,7 @@ module "vscode" {
 
 ### Open in a specific directory
 
-```hcl
+```tf
 module "vscode" {
   source = "registry.coder.com/modules/vscode-desktop/coder"
   version = "1.0.0"

--- a/vscode-desktop/README.md
+++ b/vscode-desktop/README.md
@@ -15,8 +15,8 @@ Uses the [Coder Remote VS Code Extension](https://github.com/coder/vscode-coder)
 
 ```tf
 module "vscode" {
-  source = "registry.coder.com/modules/vscode-desktop/coder"
-  version = "1.0.0"
+  source   = "registry.coder.com/modules/vscode-desktop/coder"
+  version  = "1.0.0"
   agent_id = coder_agent.example.id
 }
 ```
@@ -27,9 +27,9 @@ module "vscode" {
 
 ```tf
 module "vscode" {
-  source = "registry.coder.com/modules/vscode-desktop/coder"
-  version = "1.0.0"
+  source   = "registry.coder.com/modules/vscode-desktop/coder"
+  version  = "1.0.0"
   agent_id = coder_agent.example.id
-  folder = "/home/coder/project"
+  folder   = "/home/coder/project"
 }
 ```

--- a/vscode-web/README.md
+++ b/vscode-web/README.md
@@ -11,7 +11,7 @@ tags: [helper, ide, vscode, web]
 
 Automatically install [Visual Studio Code Server](https://code.visualstudio.com/docs/remote/vscode-server) in a workspace using the [VS Code CLI](https://code.visualstudio.com/docs/editor/command-line) and create an app to access it via the dashboard.
 
-```hcl
+```tf
 module "vscode-web" {
   source         = "registry.coder.com/modules/vscode-web/coder"
   version        = "1.0.0"
@@ -26,7 +26,7 @@ module "vscode-web" {
 
 ### Install VS Code Web to a custom folder
 
-```hcl
+```tf
 module "vscode-web" {
   source          = "registry.coder.com/modules/vscode-web/coder"
   version         = "1.0.0"

--- a/vscode-web/README.md
+++ b/vscode-web/README.md
@@ -28,11 +28,11 @@ module "vscode-web" {
 
 ```tf
 module "vscode-web" {
-  source          = "registry.coder.com/modules/vscode-web/coder"
-  version         = "1.0.0"
-  agent_id        = coder_agent.example.id
-  install_dir     = "/home/coder/.vscode-web"
-  folder          = "/home/coder"
-  accept_license  = true
+  source         = "registry.coder.com/modules/vscode-web/coder"
+  version        = "1.0.0"
+  agent_id       = coder_agent.example.id
+  install_dir    = "/home/coder/.vscode-web"
+  folder         = "/home/coder"
+  accept_license = true
 }
 ```


### PR DESCRIPTION
This PR enables Terraform formatting in markdown files (via `bun fmt`). Since the `prettier-plugin-terraform-formatter` plugin doesn't register `hcl` we also rename all code-blocks to `tf`, atlernatively we could patch the plugin but I think this is fine.

- chore: add prettier terraform formatting in markdown files
- rename `hcl` codeblocks to `tf` to enable formatter
- bun fmt
- fix invalid tf
- bun fmt
