### PR TITLE
chore: lint for tf/hcl blocks

### DIFF
--- a/lint.ts
+++ b/lint.ts
@@ -13,9 +13,39 @@ let badExit = false;
 // error reports an error to the console and sets badExit to true
 // so that the process will exit with a non-zero exit code.
 const error = (...data: any[]) => {
-    console.error(...data);
-    badExit = true;
-}
+  console.error(...data);
+  badExit = true;
+};
+
+const verifyCodeBlocks = (
+  tokens: marked.Token[],
+  res = {
+    codeIsTF: false,
+    codeIsHCL: false,
+  }
+) => {
+  for (const token of tokens) {
+    // Check in-depth.
+    if (token.type === "list") {
+      verifyCodeBlocks(token.items, res);
+      continue;
+    }
+    if (token.type === "list_item") {
+      verifyCodeBlocks(token.tokens, res);
+      continue;
+    }
+
+    if (token.type === "code") {
+      if (token.lang === "tf") {
+        res.codeIsTF = true;
+      }
+      if (token.lang === "hcl") {
+        res.codeIsHCL = true;
+      }
+    }
+  }
+  return res;
+};
 
 // Ensures that each README has the proper format.
 // Exits with 0 if all is good!
@@ -88,6 +118,14 @@ for (const dir of dirs) {
   }
   if (!code) {
     error(dir.name, "missing example code block after paragraph");
+  }
+
+  const { codeIsTF, codeIsHCL } = verifyCodeBlocks(tokens);
+  if (!codeIsTF) {
+    error(dir.name, "missing example tf code block");
+  }
+  if (codeIsHCL) {
+    error(dir.name, "hcl code block should be tf");
   }
 }
 


### PR DESCRIPTION
This PR lints that there is at least one `tf` block and no `hcl` blocks in the READMEs.

Ref: https://github.com/coder/modules/pull/134#issuecomment-1913148604
