### PR TITLE
fix(git-commit-signing): fix SSH key permissions

### DIFF
--- a/git-commit-signing/run.sh
+++ b/git-commit-signing/run.sh
@@ -31,8 +31,8 @@ jq --raw-output ".private_key" > ~/.ssh/git-commit-signing/coder << EOF
 $ssh_key
 EOF
 
-chmod -R 400 ~/.ssh/git-commit-signing/coder
-chmod -R 400 ~/.ssh/git-commit-signing/coder.pub
+chmod -R 600 ~/.ssh/git-commit-signing/coder
+chmod -R 644 ~/.ssh/git-commit-signing/coder.pub
 
 echo "Configuring git to use the SSH key"
 


### PR DESCRIPTION
Closes #149.
in Linux it's fine to modify a file's permissions that only has read permissions if you're the owner, but you still can't write to them, so if the home folder of the user is persisted, then it'll cause issues on every startup, this PR makes the files writable by the owner.

`~/.ssh/git-commit-signing/coder` goes from `400` to `600`
`~/.ssh/git-commit-signing/coder.pub` goes from `400` to `644`

these are the default values when using `ssh-keygen`, I don't know why I didn't use those permissions when writing the script.