### PR TITLE
Add slug to code server

### DIFF
--- a/code-server/main.tf
+++ b/code-server/main.tf
@@ -32,6 +32,12 @@ variable "display_name" {
   default     = "code-server"
 }
 
+variable "slug" {
+  type        = string
+  description = "The slug for the code-server application."
+  default     = "code-server"
+}
+
 variable "settings" {
   type        = map(string)
   description = "A map of settings to apply to code-server."
@@ -89,7 +95,7 @@ resource "coder_script" "code-server" {
 
 resource "coder_app" "code-server" {
   agent_id     = var.agent_id
-  slug         = "code-server"
+  slug         = var.slug
   display_name = var.display_name
   url          = "http://localhost:${var.port}/${var.folder != "" ? "?folder=${urlencode(var.folder)}" : ""}"
   icon         = "/icon/code.svg"


### PR DESCRIPTION
This PR:
- Adds a `slug` var to the code-server module
- Align the url structure of the vscode-web module with the code-server module