### PR TITLE
ci: fix ci permissions

### DIFF
--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-readme:
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This fixes the permission where GA action is unable to submit a PR. See [failed](https://github.com/coder/modules/actions/runs/7947069312/job/21695479135) run for details.
I would appreciate a quick approval.