### PR TITLE
Add terraform validation to linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "test": "bun test",
     "fmt": "bun x prettier -w **/*.sh .sample/run.sh new.sh **/*.ts **/*.md *.md && terraform fmt **/*.tf .sample/main.tf",
     "fmt:ci": "bun x prettier --check **/*.sh .sample/run.sh new.sh **/*.ts **/*.md *.md && terraform fmt -check **/*.tf .sample/main.tf",
-    "lint": "bun run lint.ts",
+    "lint": "bun run lint.ts && ./terraform_validate.sh",
     "update-version": "./update-version.sh"
   },
   "devDependencies": {

--- a/terraform_validate.sh
+++ b/terraform_validate.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Function to run terraform init and validate in a directory
+run_terraform() {
+  local dir="$1"
+  echo "Running terraform init and validate in $dir"
+  cd "$dir" || exit
+  terraform init
+  terraform validatecd 
+  cd - || exit
+}
+
+# Main script
+main() {
+  # Get the current directory
+  current_dir=$(pwd)
+
+  # Find all subdirectories containing a main.tf file
+  subdirs=$(find "$current_dir" -type f -name "main.tf" -exec dirname {} \;)
+
+  # Run terraform init and validate in each subdirectory
+  for dir in $subdirs; do
+    run_terraform "$dir"
+  done
+}
+
+# Run the main script
+main


### PR DESCRIPTION
This pull request adds terraform validation to the existing linting process. It includes a new script that runs terraform init and validate in each subdirectory containing a main.tf file. This ensures that the terraform code is valid and follows best practices.

Closes #143