### PR TITLE
feat(hcp-vault-secrets): add `project_id` variable to HCP provider

### DIFF
--- a/hcp-vault-secrets/README.md
+++ b/hcp-vault-secrets/README.md
@@ -17,8 +17,8 @@ module "vault" {
   source     = "registry.coder.com/modules/hcp-vault-secrets/coder"
   version    = "1.0.3"
   agent_id   = coder_agent.example.id
-  project_id = "aaa-bbb-ccc"
   app_name   = "demo-app"
+  project_id = "aaa-bbb-ccc"
 }
 ```
 

--- a/hcp-vault-secrets/README.md
+++ b/hcp-vault-secrets/README.md
@@ -14,10 +14,11 @@ This module lets you fetch all or selective secrets from a [HCP Vault Secrets](h
 
 ```tf
 module "vault" {
-  source   = "registry.coder.com/modules/hcp-vault-secrets/coder"
-  version  = "1.0.3"
-  agent_id = coder_agent.example.id
-  app_name = "demo-app"
+  source     = "registry.coder.com/modules/hcp-vault-secrets/coder"
+  version    = "1.0.3"
+  agent_id   = coder_agent.example.id
+  project_id = "aaa-bbb-ccc"
+  app_name   = "demo-app"
 }
 ```
 
@@ -29,6 +30,7 @@ To configure the HCP Vault Secrets module, follow these steps,
 2. Create an HCP Service Principal from the HCP Vault Secrets app in the HCP console. This will give you the `HCP_CLIENT_ID` and `HCP_CLIENT_SECRET` that you need to authenticate with HCP Vault Secrets.
    ![HCP vault secrets credentials](../.images/hcp-vault-secrets-credentials.png)
 3. Set `HCP_CLIENT_ID` and `HCP_CLIENT_SECRET` variables on the coder provisioner (recommended) or supply them as input to the module.
+4. Set the `project_id`. This is the ID of the project where the HCP Vault Secrets app is running.
 
 > See the [HCP Vault Secrets documentation](https://developer.hashicorp.com/hcp/docs/vault-secrets) for more information.
 
@@ -38,10 +40,11 @@ To fetch all secrets from the HCP Vault Secrets app, skip the `secrets` input.
 
 ```tf
 module "vault" {
-  source   = "registry.coder.com/modules/hcp-vault-secrets/coder"
-  version  = "1.0.3"
-  agent_id = coder_agent.example.id
-  app_name = "demo-app"
+  source     = "registry.coder.com/modules/hcp-vault-secrets/coder"
+  version    = "1.0.3"
+  agent_id   = coder_agent.example.id
+  app_name   = "demo-app"
+  project_id = "aaa-bbb-ccc"
 }
 ```
 
@@ -51,11 +54,12 @@ To fetch selective secrets from the HCP Vault Secrets app, set the `secrets` inp
 
 ```tf
 module "vault" {
-  source   = "registry.coder.com/modules/hcp-vault-secrets/coder"
-  version  = "1.0.3"
-  agent_id = coder_agent.example.id
-  app_name = "demo-app"
-  secrets  = ["MY_SECRET_1", "MY_SECRET_2"]
+  source     = "registry.coder.com/modules/hcp-vault-secrets/coder"
+  version    = "1.0.3"
+  agent_id   = coder_agent.example.id
+  app_name   = "demo-app"
+  project_id = "aaa-bbb-ccc"
+  secrets    = ["MY_SECRET_1", "MY_SECRET_2"]
 }
 ```
 
@@ -69,6 +73,7 @@ module "vault" {
   version       = "1.0.3"
   agent_id      = coder_agent.example.id
   app_name      = "demo-app"
+  project_id    = "aaa-bbb-ccc"
   client_id     = "HCP_CLIENT_ID"
   client_secret = "HCP_CLIENT_SECRET"
 }

--- a/hcp-vault-secrets/main.tf
+++ b/hcp-vault-secrets/main.tf
@@ -16,6 +16,7 @@ terraform {
 provider "hcp" {
   client_id     = var.client_id
   client_secret = var.client_secret
+  project_id    = var.project_id 
 }
 
 provider "coder" {}
@@ -23,6 +24,11 @@ provider "coder" {}
 variable "agent_id" {
   type        = string
   description = "The ID of a Coder agent."
+}
+
+variable "project_id" {
+  type        = string
+  description = "The ID of the HCP project."
 }
 
 variable "client_id" {

--- a/hcp-vault-secrets/main.tf
+++ b/hcp-vault-secrets/main.tf
@@ -16,7 +16,7 @@ terraform {
 provider "hcp" {
   client_id     = var.client_id
   client_secret = var.client_secret
-  project_id    = var.project_id 
+  project_id    = var.project_id
 }
 
 provider "coder" {}


### PR DESCRIPTION
adds `projects_id` as an input.