### PR TITLE
feat: add `order` variable to `coder_app` modules

### DIFF
--- a/.sample/main.tf
+++ b/.sample/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.12"
+      version = ">= 0.14.2"
     }
   }
 }

--- a/.sample/main.tf
+++ b/.sample/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.17.0"
+      version = ">= 0.17"
     }
   }
 }

--- a/.sample/main.tf
+++ b/.sample/main.tf
@@ -50,6 +50,12 @@ variable "mutable" {
   description = "Whether the parameter is mutable."
   default     = true
 }
+
+variable "order" {
+  type        = number
+  description = "The order determines the position of app in the UI presentation. The lowest order is shown first and apps with equal order are sorted by name (ascending order)."
+  default     = null
+}
 # Add other variables here
 
 
@@ -72,6 +78,7 @@ resource "coder_app" "MODULE_NAME" {
   icon         = local.icon_url
   subdomain    = false
   share        = "owner"
+  order        = var.order
 
   # Remove if the app does not have a healthcheck endpoint
   healthcheck {

--- a/.sample/main.tf
+++ b/.sample/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.14.2"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/code-server/main.tf
+++ b/code-server/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.12"
+      version = ">= 0.14.2"
     }
   }
 }

--- a/code-server/main.tf
+++ b/code-server/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.17.0"
+      version = ">= 0.17"
     }
   }
 }

--- a/code-server/main.tf
+++ b/code-server/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.14.2"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/code-server/main.tf
+++ b/code-server/main.tf
@@ -77,6 +77,12 @@ variable "share" {
   }
 }
 
+variable "order" {
+  type        = number
+  description = "The order determines the position of app in the UI presentation. The lowest order is shown first and apps with equal order are sorted by name (ascending order)."
+  default     = null
+}
+
 resource "coder_script" "code-server" {
   agent_id     = var.agent_id
   display_name = "code-server"
@@ -101,6 +107,7 @@ resource "coder_app" "code-server" {
   icon         = "/icon/code.svg"
   subdomain    = false
   share        = var.share
+  order        = var.order
 
   healthcheck {
     url       = "http://localhost:${var.port}/healthz"

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.12"
+      version = ">= 0.14.2"
     }
   }
 }

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.17.0"
+      version = ">= 0.17"
     }
   }
 }

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.14.2"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -52,6 +52,12 @@ variable "share" {
   }
 }
 
+variable "order" {
+  type        = number
+  description = "The order determines the position of app in the UI presentation. The lowest order is shown first and apps with equal order are sorted by name (ascending order)."
+  default     = null
+}
+
 resource "coder_script" "filebrowser" {
   agent_id     = var.agent_id
   display_name = "File Browser"
@@ -74,4 +80,5 @@ resource "coder_app" "filebrowser" {
   icon         = "https://raw.githubusercontent.com/filebrowser/logo/master/icon_raw.svg"
   subdomain    = true
   share        = var.share
+  order        = var.order
 }

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.17.0"
+      version = ">= 0.17"
     }
   }
 }

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.14.2"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -34,6 +34,12 @@ variable "default" {
   description = "Default IDE"
 }
 
+variable "order" {
+  type        = number
+  description = "The order determines the position of app in the UI presentation. The lowest order is shown first and apps with equal order are sorted by name (ascending order)."
+  default     = null
+}
+
 variable "jetbrains_ide_versions" {
   type = map(object({
     build_number = string
@@ -184,6 +190,7 @@ resource "coder_app" "gateway" {
   display_name = try(lookup(local.jetbrains_ides, data.coder_parameter.jetbrains_ide.value).name, "JetBrains IDE")
   icon         = try(lookup(local.jetbrains_ides, data.coder_parameter.jetbrains_ide.value).icon, "/icon/gateway.svg")
   external     = true
+  order        = var.order
   url = join("", [
     "jetbrains-gateway://connect#type=coder&workspace=",
     data.coder_workspace.me.name,

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.11"
+      version = ">= 0.14.2"
     }
   }
 }

--- a/jupyter-notebook/main.tf
+++ b/jupyter-notebook/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.12"
+      version = ">= 0.14.2"
     }
   }
 }

--- a/jupyter-notebook/main.tf
+++ b/jupyter-notebook/main.tf
@@ -36,6 +36,12 @@ variable "share" {
   }
 }
 
+variable "order" {
+  type        = number
+  description = "The order determines the position of app in the UI presentation. The lowest order is shown first and apps with equal order are sorted by name (ascending order)."
+  default     = null
+}
+
 resource "coder_script" "jupyter-notebook" {
   agent_id     = var.agent_id
   display_name = "jupyter-notebook"
@@ -55,4 +61,5 @@ resource "coder_app" "jupyter-notebook" {
   icon         = "/icon/jupyter.svg"
   subdomain    = true
   share        = var.share
+  order        = var.order
 }

--- a/jupyter-notebook/main.tf
+++ b/jupyter-notebook/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.17.0"
+      version = ">= 0.17"
     }
   }
 }

--- a/jupyter-notebook/main.tf
+++ b/jupyter-notebook/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.14.2"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/jupyterlab/main.tf
+++ b/jupyterlab/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.12"
+      version = ">= 0.14.2"
     }
   }
 }

--- a/jupyterlab/main.tf
+++ b/jupyterlab/main.tf
@@ -36,6 +36,12 @@ variable "share" {
   }
 }
 
+variable "order" {
+  type        = number
+  description = "The order determines the position of app in the UI presentation. The lowest order is shown first and apps with equal order are sorted by name (ascending order)."
+  default     = null
+}
+
 resource "coder_script" "jupyterlab" {
   agent_id     = var.agent_id
   display_name = "jupyterlab"
@@ -55,4 +61,5 @@ resource "coder_app" "jupyterlab" {
   icon         = "/icon/jupyter.svg"
   subdomain    = true
   share        = var.share
+  order        = var.order
 }

--- a/jupyterlab/main.tf
+++ b/jupyterlab/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.17.0"
+      version = ">= 0.17"
     }
   }
 }

--- a/jupyterlab/main.tf
+++ b/jupyterlab/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.14.2"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/vscode-desktop/main.test.ts
+++ b/vscode-desktop/main.test.ts
@@ -20,5 +20,18 @@ describe("vscode-desktop", async () => {
     expect(state.outputs.vscode_url.value).toBe(
       "vscode://coder.coder-remote/open?owner=default&workspace=default&token=$SESSION_TOKEN",
     );
+
+    const resources: any = state.resources;
+    expect(resources[1].instances[0].attributes.order).toBeNull();
+  });
+
+  it("expect order to be set", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      order: "22",
+    });
+
+    const resources: any = state.resources;
+    expect(resources[1].instances[0].attributes.order).toBe(22);
   });
 });

--- a/vscode-desktop/main.tf
+++ b/vscode-desktop/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.12"
+      version = ">= 0.14.2"
     }
   }
 }

--- a/vscode-desktop/main.tf
+++ b/vscode-desktop/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.17.0"
+      version = ">= 0.17"
     }
   }
 }

--- a/vscode-desktop/main.tf
+++ b/vscode-desktop/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.14.2"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/vscode-desktop/main.tf
+++ b/vscode-desktop/main.tf
@@ -20,6 +20,12 @@ variable "folder" {
   default     = ""
 }
 
+variable "order" {
+  type        = number
+  description = "The order determines the position of app in the UI presentation. The lowest order is shown first and apps with equal order are sorted by name (ascending order)."
+  default     = null
+}
+
 data "coder_workspace" "me" {}
 
 resource "coder_app" "vscode" {
@@ -28,6 +34,7 @@ resource "coder_app" "vscode" {
   icon         = "/icon/code.svg"
   slug         = "vscode"
   display_name = "VS Code Desktop"
+  order        = var.order
   url = var.folder != "" ? join("", [
     "vscode://coder.coder-remote/open?owner=",
     data.coder_workspace.me.owner,

--- a/vscode-web/main.tf
+++ b/vscode-web/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.12"
+      version = ">= 0.14.2"
     }
   }
 }

--- a/vscode-web/main.tf
+++ b/vscode-web/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.17.0"
+      version = ">= 0.17"
     }
   }
 }

--- a/vscode-web/main.tf
+++ b/vscode-web/main.tf
@@ -85,6 +85,12 @@ variable "telemetry_level" {
   }
 }
 
+variable "order" {
+  type        = number
+  description = "The order determines the position of app in the UI presentation. The lowest order is shown first and apps with equal order are sorted by name (ascending order)."
+  default     = null
+}
+
 resource "coder_script" "vscode-web" {
   agent_id     = var.agent_id
   display_name = "VS Code Web"
@@ -107,6 +113,7 @@ resource "coder_app" "vscode-web" {
   icon         = "/icon/code.svg"
   subdomain    = true
   share        = var.share
+  order        = var.order
 
   healthcheck {
     url       = "http://localhost:${var.port}/healthz"

--- a/vscode-web/main.tf
+++ b/vscode-web/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.14.2"
+      version = ">= 0.17.0"
     }
   }
 }


### PR DESCRIPTION
Add per the coder docs coder applications can be reordered in the ui via the order field

https://coder.com/docs/v2/latest/templates/resource-ordering#applications

This change allows this:

```hcl
module "code-server" {
  source          = "registry.coder.com/modules/code-server/coder"
  version         = "1.0.5"
  agent_id        = coder_agent.main.id
  install_version = "4.8.3"
  order           = 2
}

module "filebrowser" {
  source   = "registry.coder.com/modules/filebrowser/coder"
  version  = "1.0.3"
  agent_id = coder_agent.example.id
  folder   = "/home/coder/project"
  order    = 1
}
```

See issue #178 