### PR TITLE
doc(coder-server): code-server module does not have offline attribute

### DIFF
--- a/code-server/README.md
+++ b/code-server/README.md
@@ -79,16 +79,3 @@ module "code-server" {
   extensions = ["dracula-theme.theme-dracula", "ms-azuretools.vscode-docker"]
 }
 ```
-
-### Offline Mode
-
-Just run code-server in the background, don't fetch it from GitHub:
-
-```tf
-module "code-server" {
-  source   = "registry.coder.com/modules/code-server/coder"
-  version  = "1.0.5"
-  agent_id = coder_agent.example.id
-  offline  = true
-}
-```


### PR DESCRIPTION
Doc mention offline suport 

```terraform
module "code-server" {
  source         = "registry.coder.com/modules/code-server/coder"
  version        = "1.0.7"
  agent_id       = coder_agent.main.id
  folder         = "/workspace/${local.folder_name}"
  install_prefix = "/workspace/.coder-server"
  offline = true
  settings = {
    "workbench.colorTheme" : "Visual Studio Dark"
    "workbench.startupEditor" : "readme"
  }
  extensions = [
    "ms-python.python",
    "hashicorp.terraform",
    "ms-azuretools.vscode-docker"
  ]
}
```

However there is no filed for this

```
Error: Unsupported argument
on main.tf line 219, in module "code-server":
  219:   offline = true
An argument named "offline" is not expected here.
```

closes #181