### PR TITLE
Fix `nodejs`: Create directory before executing script

### DIFF
--- a/nodejs/main.tf
+++ b/nodejs/main.tf
@@ -22,8 +22,8 @@ variable "nvm_version" {
 
 variable "nvm_install_prefix" {
   type        = string
-  description = "The prefix to install nvm to."
-  default     = "$HOME/.nvm"
+  description = "The prefix to install nvm to (relative to $HOME)."
+  default     = ".nvm"
 }
 
 variable "node_versions" {

--- a/nodejs/run.sh
+++ b/nodejs/run.sh
@@ -11,6 +11,7 @@ RESET='\033[0m'
 printf "$${BOLD}Installing nvm!$${RESET}\n"
 
 export NVM_DIR="$${INSTALL_PREFIX}/nvm"
+mkdir -p "$NVM_DIR"
 
 script="$(curl -sS -o- "https://raw.githubusercontent.com/nvm-sh/nvm/$${NVM_VERSION}/install.sh" 2>&1)"
 if [ $? -ne 0 ]; then

--- a/nodejs/run.sh
+++ b/nodejs/run.sh
@@ -10,7 +10,7 @@ RESET='\033[0m'
 
 printf "$${BOLD}Installing nvm!$${RESET}\n"
 
-export NVM_DIR="$${INSTALL_PREFIX}/nvm"
+export NVM_DIR="$HOME/$${INSTALL_PREFIX}/nvm"
 mkdir -p "$NVM_DIR"
 
 script="$(curl -sS -o- "https://raw.githubusercontent.com/nvm-sh/nvm/$${NVM_VERSION}/install.sh" 2>&1)"


### PR DESCRIPTION
Something I did not notice during my testing was, that the directory for `nvm` needs to be created first before the script can be installed. This PR fixes this. 