### PR TITLE
fix(git-commit-signing): disable curl stderr output

### DIFF
--- a/git-commit-signing/run.sh
+++ b/git-commit-signing/run.sh
@@ -21,7 +21,8 @@ echo "Downloading SSH key"
 
 ssh_key=$(curl --request GET \
   --url "${CODER_AGENT_URL}api/v2/workspaceagents/me/gitsshkey" \
-  --header "Coder-Session-Token: ${CODER_AGENT_TOKEN}")
+  --header "Coder-Session-Token: ${CODER_AGENT_TOKEN}" \
+  --silent --show-error)
 
 jq --raw-output ".public_key" > ~/.ssh/git-commit-signing/coder.pub << EOF
 $ssh_key


### PR DESCRIPTION
The module currently logs some output to stderr when there's no error, this PR fixes that.
I tested it and it works

```tf
module "git-commit-signing" {
  source   = "git::https://github.com/phorcys420/coder-modules.git//git-commit-signing?ref=git-commit-signing-fix"
  agent_id = coder_agent.dev.id
}
```