### PR TITLE
feat(vscode-web): add support for settings

### DIFF
--- a/vscode-web/README.md
+++ b/vscode-web/README.md
@@ -48,3 +48,20 @@ module "vscode-web" {
   accept_license = true
 }
 ```
+
+### Pre-configure Settings
+
+Configure VS Code's [settings.json](https://code.visualstudio.com/docs/getstarted/settings#_settingsjson) file:
+
+```tf
+module "vscode-web" {
+  source     = "registry.coder.com/modules/vscode-web/coder"
+  version    = "1.0.8"
+  agent_id   = coder_agent.example.id
+  extensions = ["dracula-theme.theme-dracula"]
+  settings = {
+    "workbench.colorTheme" = "Dracula"
+  }
+  accept_license = true
+}
+```

--- a/vscode-web/main.tf
+++ b/vscode-web/main.tf
@@ -93,7 +93,7 @@ variable "order" {
 
 variable "settings" {
   type        = map(string)
-  description = "A map of settings to apply to code-server."
+  description = "A map of settings to apply to VS Code web."
   default     = {}
 }
 

--- a/vscode-web/main.tf
+++ b/vscode-web/main.tf
@@ -91,6 +91,12 @@ variable "order" {
   default     = null
 }
 
+variable "settings" {
+  type        = map(string)
+  description = "A map of settings to apply to code-server."
+  default     = {}
+}
+
 resource "coder_script" "vscode-web" {
   agent_id     = var.agent_id
   display_name = "VS Code Web"
@@ -101,6 +107,8 @@ resource "coder_script" "vscode-web" {
     INSTALL_PREFIX : var.install_prefix,
     EXTENSIONS : join(",", var.extensions),
     TELEMETRY_LEVEL : var.telemetry_level,
+    // This is necessary otherwise the quotes are stripped!
+    SETTINGS : replace(jsonencode(var.settings), "\"", "\\\""),
   })
   run_on_start = true
 }

--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -19,8 +19,8 @@ case "$ARCH" in
     ;;
 esac
 
-HASH=$(curl https://update.code.visualstudio.com/api/commits/stable/server-linux-$ARCH-web | cut -d '"' -f 2)
-output=$(curl -sL https://vscode.download.prss.microsoft.com/dbazure/download/stable/$HASH/vscode-server-linux-$ARCH-web.tar.gz | tar -xz -C ${INSTALL_PREFIX} --strip-components 1)
+HASH=$(curl -fsSL https://update.code.visualstudio.com/api/commits/stable/server-linux-$ARCH-web | cut -d '"' -f 2)
+output=$(curl -fsSL https://vscode.download.prss.microsoft.com/dbazure/download/stable/$HASH/vscode-server-linux-$ARCH-web.tar.gz | tar -xz -C ${INSTALL_PREFIX} --strip-components 1)
 
 if [ $? -ne 0 ]; then
   echo "Failed to install Microsoft Visual Studio Code Server: $output"

--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -44,6 +44,13 @@ for extension in "$${EXTENSIONLIST[@]}"; do
   fi
 done
 
+# Check if the settings file exists...
+if [ ! -f ~/.vscode-server/data/Machine/settings.json ]; then
+  echo "⚙️ Creating settings file..."
+  mkdir -p ~/.vscode-server/data/Machine
+  echo "${SETTINGS}" > ~/.vscode-server/data/Machine/settings.json
+fi
+
 echo "👷 Running ${INSTALL_PREFIX}/bin/code-server serve-local --port ${PORT} --accept-server-license-terms serve-local --without-connection-token --telemetry-level ${TELEMETRY_LEVEL} in the background..."
 echo "Check logs at ${LOG_PATH}!"
 "${INSTALL_PREFIX}/bin/code-server" serve-local --port "${PORT}" --accept-server-license-terms serve-local --without-connection-token --telemetry-level "${TELEMETRY_LEVEL}" > "${LOG_PATH}" 2>&1 &


### PR DESCRIPTION
Add support for settings, like code-server

```tf
module "vscode-web" {
  source     = "registry.coder.com/modules/vscode-web/coder"
  version    = "1.0.8"
  agent_id   = coder_agent.example.id
  extensions = ["dracula-theme.theme-dracula"]
  settings = {
    "workbench.colorTheme" = "Dracula"
  }
  accept_license = true
}
```

Currently saves to `~/.vscode-server/data/Machine/settings.json` as `~/.vscode-server/data/User/settings.json` does not seem to work.

related to #194
closes #196