### PR TITLE
chore(jfrog-token): set token description

### DIFF
--- a/jfrog-token/README.md
+++ b/jfrog-token/README.md
@@ -87,6 +87,26 @@ module "jfrog" {
 }
 ```
 
+### Add a custom token description
+
+```tf
+data "coder_workspace" "me" {}
+
+module "jfrog" {
+  source                   = "registry.coder.com/modules/jfrog-token/coder"
+  version                  = "1.0.5"
+  agent_id                 = coder_agent.example.id
+  jfrog_url                = "https://XXXX.jfrog.io"
+  artifactory_access_token = var.artifactory_access_token
+  token_description        = "Token for Coder workspace: ${data.coder_workspace.me.owner}/${data.coder_workspace.me.name}"
+  package_managers = {
+    "npm" : "npm",
+    "go" : "go",
+    "pypi" : "pypi"
+  }
+}
+```
+
 ### Using the access token in other terraform resources
 
 JFrog Access token is also available as a terraform output. You can use it in other terraform resources. For example, you can use it to configure an [Artifactory docker registry](https://jfrog.com/help/r/jfrog-artifactory-documentation/docker-registry) with the [docker terraform provider](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs).

--- a/jfrog-token/main.tf
+++ b/jfrog-token/main.tf
@@ -37,7 +37,7 @@ variable "artifactory_access_token" {
 variable "token_description" {
   type        = string
   description = "Free text token description. Useful for filtering and managing tokens."
-  default     = "coder-workspace-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
+  default     = "Token for Coder workspace: ${data.coder_workspace.me.owner}/${data.coder_workspace.me.name}"
 }
 
 variable "check_license" {

--- a/jfrog-token/main.tf
+++ b/jfrog-token/main.tf
@@ -34,6 +34,12 @@ variable "artifactory_access_token" {
   description = "The admin-level access token to use for JFrog."
 }
 
+variable "token_description" {
+  type        = string
+  description = "Free text token description. Useful for filtering and managing tokens."
+  default     = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
+}
+
 variable "check_license" {
   type        = bool
   description = "Toggle for pre-flight checking of Artifactory license. Default to `true`."
@@ -107,6 +113,7 @@ resource "artifactory_scoped_token" "me" {
   scopes      = ["applied-permissions/user"]
   refreshable = var.refreshable
   expires_in  = var.expires_in
+  description = var.token_description
 }
 
 data "coder_workspace" "me" {}

--- a/jfrog-token/main.tf
+++ b/jfrog-token/main.tf
@@ -37,7 +37,7 @@ variable "artifactory_access_token" {
 variable "token_description" {
   type        = string
   description = "Free text token description. Useful for filtering and managing tokens."
-  default     = "Token for Coder workspace: ${data.coder_workspace.me.owner}/${data.coder_workspace.me.name}"
+  default     = "Token for Coder workspace"
 }
 
 variable "check_license" {

--- a/jfrog-token/main.tf
+++ b/jfrog-token/main.tf
@@ -37,7 +37,7 @@ variable "artifactory_access_token" {
 variable "token_description" {
   type        = string
   description = "Free text token description. Useful for filtering and managing tokens."
-  default     = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
+  default     = "coder-workspace-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
 }
 
 variable "check_license" {


### PR DESCRIPTION
This defaults to `"coder-workspace-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"`  which will render as `coder-workspace-USER_NAME-WORKSPACE_NAME` with the option to overwrite it.