### PR TITLE
chore(git-commit-signing): use included icon for git

### DIFF
--- a/git-commit-signing/main.tf
+++ b/git-commit-signing/main.tf
@@ -16,7 +16,7 @@ variable "agent_id" {
 
 resource "coder_script" "git-commit-signing" {
   display_name = "Git commit signing"
-  icon         = "https://raw.githubusercontent.com/coder/modules/main/.icons/git.svg"
+  icon         = "/icon/git.svg"
 
   script       = file("${path.module}/run.sh")
   run_on_start = true


### PR DESCRIPTION
Change to use the Coder icon for git.svg so we don't need to fetch it externally

@phorcys420 we might want to use the include git.svg hosted by coder.