### PR TITLE
fix(vscode-web): set `--host 127.0.0.1`

### DIFF
--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -51,6 +51,6 @@ if [ ! -f ~/.vscode-server/data/Machine/settings.json ]; then
   echo "${SETTINGS}" > ~/.vscode-server/data/Machine/settings.json
 fi
 
-echo "👷 Running ${INSTALL_PREFIX}/bin/code-server serve-local --port ${PORT} --accept-server-license-terms serve-local --without-connection-token --telemetry-level ${TELEMETRY_LEVEL} in the background..."
+echo "👷 Running ${INSTALL_PREFIX}/bin/code-server serve-local --port ${PORT} --host 127.0.0.1 --accept-server-license-terms serve-local --without-connection-token --telemetry-level ${TELEMETRY_LEVEL} in the background..."
 echo "Check logs at ${LOG_PATH}!"
-"${INSTALL_PREFIX}/bin/code-server" serve-local --port "${PORT}" --accept-server-license-terms serve-local --without-connection-token --telemetry-level "${TELEMETRY_LEVEL}" > "${LOG_PATH}" 2>&1 &
+"${INSTALL_PREFIX}/bin/code-server" serve-local --port "${PORT}" --host 127.0.0.1 --accept-server-license-terms serve-local --without-connection-token --telemetry-level "${TELEMETRY_LEVEL}" > "${LOG_PATH}" 2>&1 &


### PR DESCRIPTION
MS code-server defaults to using `--host localhost`, which worked perfectly with Coder.

But recently Coder is failing to proxy vscode-web with the https://github.com/coder/coder/issues/12790 

As a workaround, setting `--host 127.0.0.1` works.

### Details

ok so Running (the default if we skip `--host`)
`/tmp/vscode-web/bin/code-server serve-local --port 13340 --host localhost --accept-server-license-terms serve-local --without-connection-token --telemetry-level error` gives
```console
Server bound to ::1:13338(IPv6)
Extension host agent listening on 13338
```
But if we set `--host 127.0.0.1`
```console
Server bound to 127.0.0.1:13338 (IPv4)
Extension host agent listening on 13338

[12:55:24] 

Web UI available at http://localhost:13338/
[12:55:24] Extension host agent started.
```
This binds to ipv4.
Is this something that changed at Coder or Microsoft?
Because vs code-server was setting --host localhost and did not change any behavior.
