### PR TITLE
feat(git-config): allow `data.coder_workspace.me.owner_email` to be blank

### DIFF
--- a/git-config/main.test.ts
+++ b/git-config/main.test.ts
@@ -44,4 +44,26 @@ describe("git-config", async () => {
       { type: "coder_env", name: "git_commmiter_name" },
     ]);
   });
+
+  it("can run apply allow_email_change enabled", async () => {
+    const state = await runTerraformApply(
+      import.meta.dir,
+      {
+        agent_id: "foo",
+        allow_username_change: "false",
+        allow_email_change: "false",
+      },
+      { CODER_WORKSPACE_OWNER_EMAIL: "foo@emai.com" },
+    );
+
+    const resources = state.resources;
+    expect(resources).toHaveLength(5);
+    expect(resources).toMatchObject([
+      { type: "coder_workspace", name: "me" },
+      { type: "coder_env", name: "git_author_email" },
+      { type: "coder_env", name: "git_author_name" },
+      { type: "coder_env", name: "git_commmiter_email" },
+      { type: "coder_env", name: "git_commmiter_name" },
+    ]);
+  });
 });

--- a/git-config/main.test.ts
+++ b/git-config/main.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import {
+  runTerraformApply,
+  runTerraformInit,
+  testRequiredVariables,
+} from "../test";
+
+describe("git-config", async () => {
+  await runTerraformInit(import.meta.dir);
+
+  testRequiredVariables(import.meta.dir, {
+    agent_id: "foo",
+  });
+
+  it("can run apply allow_username_change and allow_email_change disabled", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      allow_username_change: "false",
+      allow_email_change: "false",
+    });
+
+    const resources = state.resources;
+    expect(resources).toHaveLength(3);
+    expect(resources).toMatchObject([
+      { type: "coder_workspace", name: "me" },
+      { type: "coder_env", name: "git_author_name" },
+      { type: "coder_env", name: "git_commmiter_name" },
+    ]);
+  });
+
+  it("can run apply allow_email_change enabled", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      allow_email_change: "true",
+    });
+
+    const resources = state.resources;
+    expect(resources).toHaveLength(5);
+    expect(resources).toMatchObject([
+      { type: "coder_parameter", name: "user_email" },
+      { type: "coder_parameter", name: "username" },
+      { type: "coder_workspace", name: "me" },
+      { type: "coder_env", name: "git_author_name" },
+      { type: "coder_env", name: "git_commmiter_name" },
+    ]);
+  });
+});

--- a/git-config/main.tf
+++ b/git-config/main.tf
@@ -65,10 +65,12 @@ resource "coder_env" "git_author_email" {
   agent_id = var.agent_id
   name     = "GIT_AUTHOR_EMAIL"
   value    = coalesce(try(data.coder_parameter.user_email[0].value, ""), data.coder_workspace.me.owner_email)
+  count    = data.coder_workspace.me.owner_email != "" ? 1 : 0
 }
 
 resource "coder_env" "git_commmiter_email" {
   agent_id = var.agent_id
   name     = "GIT_COMMITTER_EMAIL"
   value    = coalesce(try(data.coder_parameter.user_email[0].value, ""), data.coder_workspace.me.owner_email)
+  count    = data.coder_workspace.me.owner_email != "" ? 1 : 0
 }

--- a/test.ts
+++ b/test.ts
@@ -171,9 +171,9 @@ export const testRequiredVariables = (
 export const runTerraformApply = async (
   dir: string,
   vars: Record<string, string>,
+  env: Record<string, string> = {},
 ): Promise<TerraformState> => {
   const stateFile = `${dir}/${crypto.randomUUID()}.tfstate`;
-  const env = {};
   Object.keys(vars).forEach((key) => (env[`TF_VAR_${key}`] = vars[key]));
   const proc = spawn(
     [


### PR DESCRIPTION
closes #162