### PR TITLE
feat: add coder_parameter_order to all data.coder_parameter fields

### DIFF
--- a/aws-region/main.test.ts
+++ b/aws-region/main.test.ts
@@ -22,4 +22,13 @@ describe("aws-region", async () => {
     });
     expect(state.outputs.value.value).toBe("us-west-2");
   });
+
+  it("set custom order for coder_parameter", async () => {
+    const order = 99;
+    const state = await runTerraformApply(import.meta.dir, {
+      coder_parameter_order: order.toString(),
+    });
+    expect(state.resources).toHaveLength(1);
+    expect(state.resources[0].instances[0].attributes.order).toBe(order);
+  });
 });

--- a/aws-region/main.tf
+++ b/aws-region/main.tf
@@ -51,6 +51,12 @@ variable "exclude" {
   type        = list(string)
 }
 
+variable "coder_parameter_order" {
+  type        = number
+  description = "The order determines the position of a template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order)."
+  default     = null
+}
+
 locals {
   # This is a static list because the regions don't change _that_
   # frequently and including the `aws_regions` data source requires
@@ -176,6 +182,7 @@ data "coder_parameter" "region" {
   display_name = var.display_name
   description  = var.description
   default      = var.default == "" ? null : var.default
+  order        = var.coder_parameter_order
   mutable      = var.mutable
   dynamic "option" {
     for_each = { for k, v in local.regions : k => v if !(contains(var.exclude, k)) }

--- a/azure-region/main.test.ts
+++ b/azure-region/main.test.ts
@@ -22,4 +22,13 @@ describe("azure-region", async () => {
     });
     expect(state.outputs.value.value).toBe("westus");
   });
+
+  it("set custom order for coder_parameter", async () => {
+    const order = 99;
+    const state = await runTerraformApply(import.meta.dir, {
+      coder_parameter_order: order.toString(),
+    });
+    expect(state.resources).toHaveLength(1);
+    expect(state.resources[0].instances[0].attributes.order).toBe(order);
+  });
 });

--- a/azure-region/main.tf
+++ b/azure-region/main.tf
@@ -50,6 +50,12 @@ variable "exclude" {
   type        = list(string)
 }
 
+variable "coder_parameter_order" {
+  type        = number
+  description = "The order determines the position of a template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order)."
+  default     = null
+}
+
 locals {
   # Note: Options are limited to 64 regions, some redundant regions have been removed.
   all_regions = {
@@ -309,6 +315,7 @@ data "coder_parameter" "region" {
   display_name = var.display_name
   description  = var.description
   default      = var.default == "" ? null : var.default
+  order        = var.coder_parameter_order
   mutable      = var.mutable
   icon         = "/icon/azure.png"
   dynamic "option" {

--- a/dotfiles/main.test.ts
+++ b/dotfiles/main.test.ts
@@ -18,4 +18,14 @@ describe("dotfiles", async () => {
     });
     expect(state.outputs.dotfiles_uri.value).toBe("");
   });
+
+  it("set custom order for coder_parameter", async () => {
+    const order = 99;
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      coder_parameter_order: order.toString(),
+    });
+    expect(state.resources).toHaveLength(2);
+    expect(state.resources[0].instances[0].attributes.order).toBe(order);
+  });
 });

--- a/dotfiles/main.tf
+++ b/dotfiles/main.tf
@@ -14,11 +14,18 @@ variable "agent_id" {
   description = "The ID of a Coder agent."
 }
 
+variable "coder_parameter_order" {
+  type        = number
+  description = "The order determines the position of a template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order)."
+  default     = null
+}
+
 data "coder_parameter" "dotfiles_uri" {
   type         = "string"
   name         = "dotfiles_uri"
   display_name = "Dotfiles URL (optional)"
   default      = ""
+  order        = var.coder_parameter_order
   description  = "Enter a URL for a [dotfiles repository](https://dotfiles.github.io) to personalize your workspace"
   mutable      = true
   icon         = "/icon/dotfiles.svg"

--- a/exoscale-instance-type/main.test.ts
+++ b/exoscale-instance-type/main.test.ts
@@ -31,4 +31,13 @@ describe("exoscale-instance-type", async () => {
       });
     }).toThrow('default value "gpu3.huge" must be defined as one of options');
   });
+
+  it("set custom order for coder_parameter", async () => {
+    const order = 99;
+    const state = await runTerraformApply(import.meta.dir, {
+      coder_parameter_order: order.toString(),
+    });
+    expect(state.resources).toHaveLength(1);
+    expect(state.resources[0].instances[0].attributes.order).toBe(order);
+  });
 });

--- a/exoscale-instance-type/main.tf
+++ b/exoscale-instance-type/main.tf
@@ -56,6 +56,12 @@ variable "exclude" {
   type        = list(string)
 }
 
+variable "coder_parameter_order" {
+  type        = number
+  description = "The order determines the position of a template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order)."
+  default     = null
+}
+
 locals {
   # https://www.exoscale.com/pricing/
 
@@ -257,6 +263,7 @@ data "coder_parameter" "instance_type" {
   display_name = var.display_name
   description  = var.description
   default      = var.default == "" ? null : var.default
+  order        = var.coder_parameter_order
   mutable      = var.mutable
   dynamic "option" {
     for_each = [for k, v in concat(

--- a/exoscale-zone/main.test.ts
+++ b/exoscale-zone/main.test.ts
@@ -22,4 +22,13 @@ describe("exoscale-zone", async () => {
     });
     expect(state.outputs.value.value).toBe("at-vie-1");
   });
+
+  it("set custom order for coder_parameter", async () => {
+    const order = 99;
+    const state = await runTerraformApply(import.meta.dir, {
+      coder_parameter_order: order.toString(),
+    });
+    expect(state.resources).toHaveLength(1);
+    expect(state.resources[0].instances[0].attributes.order).toBe(order);
+  });
 });

--- a/exoscale-zone/main.tf
+++ b/exoscale-zone/main.tf
@@ -51,6 +51,11 @@ variable "exclude" {
   type        = list(string)
 }
 
+variable "coder_parameter_order" {
+  type        = number
+  description = "The order determines the position of a template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order)."
+  default     = null
+}
 
 locals {
   # This is a static list because the zones don't change _that_
@@ -94,6 +99,7 @@ data "coder_parameter" "zone" {
   display_name = var.display_name
   description  = var.description
   default      = var.default == "" ? null : var.default
+  order        = var.coder_parameter_order
   mutable      = var.mutable
   dynamic "option" {
     for_each = { for k, v in local.zones : k => v if !(contains(var.exclude, k)) }

--- a/gcp-region/main.test.ts
+++ b/gcp-region/main.test.ts
@@ -40,4 +40,13 @@ describe("gcp-region", async () => {
     });
     expect(state.outputs.value.value).toBe("us-west2-b");
   });
+
+  it("set custom order for coder_parameter", async () => {
+    const order = 99;
+    const state = await runTerraformApply(import.meta.dir, {
+      coder_parameter_order: order.toString(),
+    });
+    expect(state.resources).toHaveLength(1);
+    expect(state.resources[0].instances[0].attributes.order).toBe(order);
+  });
 });

--- a/gcp-region/main.tf
+++ b/gcp-region/main.tf
@@ -63,6 +63,12 @@ variable "single_zone_per_region" {
   type        = bool
 }
 
+variable "coder_parameter_order" {
+  type        = number
+  description = "The order determines the position of a template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order)."
+  default     = null
+}
+
 locals {
   zones = {
     # US Central
@@ -715,6 +721,7 @@ data "coder_parameter" "region" {
   icon         = "/icon/gcp.png"
   mutable      = var.mutable
   default      = var.default != null && var.default != "" && (!var.gpu_only || try(local.zones[var.default].gpu, false)) ? var.default : null
+  order        = var.coder_parameter_order
   dynamic "option" {
     for_each = {
       for k, v in local.zones : k => v

--- a/git-config/main.test.ts
+++ b/git-config/main.test.ts
@@ -66,4 +66,34 @@ describe("git-config", async () => {
       { type: "coder_env", name: "git_commmiter_name" },
     ]);
   });
+
+  it("set custom order for coder_parameter for both fields", async () => {
+    const order = 20;
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      allow_username_change: "true",
+      allow_email_change: "true",
+      coder_parameter_order: order.toString(),
+    });
+    expect(state.resources).toHaveLength(5);
+    // user_email order is the same as the order
+    expect(state.resources[0].instances[0].attributes.order).toBe(order);
+    // username order is incremented by 1
+    // @ts-ignore: Object is possibly 'null'.
+    expect(state.resources[1].instances[0]?.attributes.order).toBe(order + 1);
+  });
+
+  it("set custom order for coder_parameter for just username", async () => {
+    const order = 30;
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      allow_email_change: "false",
+      allow_username_change: "true",
+      coder_parameter_order: order.toString(),
+    });
+    expect(state.resources).toHaveLength(4);
+    // user_email was not created
+    // username order is incremented by 1
+    expect(state.resources[0].instances[0].attributes.order).toBe(order + 1);
+  });
 });

--- a/git-config/main.tf
+++ b/git-config/main.tf
@@ -26,6 +26,17 @@ variable "allow_email_change" {
   default     = false
 }
 
+variable "coder_parameter_user_email_order" {
+  type        = number
+  description = "The order determines the position of the 'user_email' template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order)."
+  default     = null
+}
+
+variable "coder_parameter_username_order" {
+  type        = number
+  description = "The order determines the position of the 'username' template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order)."
+  default     = null
+}
 
 data "coder_workspace" "me" {}
 
@@ -34,6 +45,7 @@ data "coder_parameter" "user_email" {
   name         = "user_email"
   type         = "string"
   default      = ""
+  order        = var.coder_parameter_user_email_order
   description  = "Git user.email to be used for commits. Leave empty to default to Coder user's email."
   display_name = "Git config user.email"
   mutable      = true
@@ -44,6 +56,7 @@ data "coder_parameter" "username" {
   name         = "username"
   type         = "string"
   default      = ""
+  order        = var.coder_parameter_username_order
   description  = "Git user.name to be used for commits. Leave empty to default to Coder user's Full Name."
   display_name = "Full Name for Git config"
   mutable      = true

--- a/git-config/main.tf
+++ b/git-config/main.tf
@@ -26,15 +26,9 @@ variable "allow_email_change" {
   default     = false
 }
 
-variable "coder_parameter_user_email_order" {
+variable "coder_parameter_order" {
   type        = number
-  description = "The order determines the position of the 'user_email' template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order)."
-  default     = null
-}
-
-variable "coder_parameter_username_order" {
-  type        = number
-  description = "The order determines the position of the 'username' template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order)."
+  description = "The order determines the position of a template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order)."
   default     = null
 }
 
@@ -45,7 +39,7 @@ data "coder_parameter" "user_email" {
   name         = "user_email"
   type         = "string"
   default      = ""
-  order        = var.coder_parameter_user_email_order
+  order        = var.coder_parameter_order != null ? var.coder_parameter_order + 0 : null
   description  = "Git user.email to be used for commits. Leave empty to default to Coder user's email."
   display_name = "Git config user.email"
   mutable      = true
@@ -56,7 +50,7 @@ data "coder_parameter" "username" {
   name         = "username"
   type         = "string"
   default      = ""
-  order        = var.coder_parameter_username_order
+  order        = var.coder_parameter_order != null ? var.coder_parameter_order + 1 : null
   description  = "Git user.name to be used for commits. Leave empty to default to Coder user's Full Name."
   display_name = "Full Name for Git config"
   mutable      = true


### PR DESCRIPTION
Add `coder_parameter_order` variable to modules that have a data coder_parameter

- [x] aws-region
- [x] azure-region
- [x] dotfiles
- [x] exoscale-instance-type
- [x] exoscale-zone
- [x] gcp-region
- [x] git-config (has 2 parameters)

## Examples

> NOTE: add `coder_parameter_order` for `git-config` could be increments by one, `gcp-region` order should be higher to start with. So intervals by 10 is always safe

```tf
module "git-config" {
  source                = "registry.coder.com/modules/git-config/coder"
  version               = "1.0.11"
  agent_id              = coder_agent.example.id
  allow_email_change    = true
  coder_parameter_order = 10
}

module "gcp-region" {
  source                = "registry.coder.com/modules/gcp-region/coder"
  version               = "1.0.11"
  regions               = ["us", "europe"]
  coder_parameter_order = 20
}

// etc..
```

related to #207