### PR TITLE
Dotfiles template default repo

### DIFF
--- a/dotfiles/README.md
+++ b/dotfiles/README.md
@@ -1,20 +1,54 @@
----
-display_name: Dotfiles
-description: Allow developers to optionally bring their own dotfiles repository to customize their shell and IDE settings!
-icon: ../.icons/dotfiles.svg
-maintainer_github: coder
-verified: true
-tags: [helper]
----
+terraform {
+  required_version = ">= 1.0"
 
-# Dotfiles
-
-Allow developers to optionally bring their own [dotfiles repository](https://dotfiles.github.io)! Under the hood, this module uses the [coder dotfiles](https://coder.com/docs/v2/latest/dotfiles) command.
-
-```tf
-module "dotfiles" {
-  source   = "registry.coder.com/modules/dotfiles/coder"
-  version  = "1.0.2"
-  agent_id = coder_agent.example.id
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = ">= 0.12"
+    }
+  }
 }
-```
+
+variable "agent_id" {
+  type        = string
+  description = "The ID of a Coder agent."
+}
+
+variable "default_dotfiles_uri" {
+  type        = string
+  description = "The default dotfiles URI if the workspace user does not provide one."
+  default     = ""
+}
+
+data "coder_parameter" "dotfiles_uri" {
+  type         = "string"
+  name         = "dotfiles_uri"
+  display_name = "Dotfiles URL (optional)"
+  default      = var.default_dotfiles_uri
+  description  = "Enter a URL for a [dotfiles repository](https://dotfiles.github.io) to personalize your workspace"
+  mutable      = true
+  icon         = "/icon/dotfiles.svg"
+}
+
+resource "coder_script" "personalize" {
+  agent_id     = var.agent_id
+  script       = <<-EOT
+    DOTFILES_URI="${data.coder_parameter.dotfiles_uri.value}"
+    if [ -n "$${DOTFILES_URI// }" ]; then
+    coder dotfiles "$DOTFILES_URI" -y 2>&1 | tee -a ~/.dotfiles.log
+    fi
+    EOT
+  display_name = "Dotfiles"
+  icon         = "/icon/dotfiles.svg"
+  run_on_start = true
+}
+
+output "dotfiles_uri" {
+  description = "Dotfiles URI"
+  value       = data.coder_parameter.dotfiles_uri.value
+}
+
+output "dotfiles_default_uri" {
+  description = "Dotfiles Default URI"
+  value       = var.default_dotfiles_uri
+}

--- a/dotfiles/main.test.ts
+++ b/dotfiles/main.test.ts
@@ -18,4 +18,13 @@ describe("dotfiles", async () => {
     });
     expect(state.outputs.dotfiles_uri.value).toBe("");
   });
+  
+  it("set a default dotfiles_uri", async () => {
+    const default_dotfiles_uri = "foo";
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      default_dotfiles_uri,
+    });
+    expect(state.outputs.dotfiles_uri.value).toBe(default_dotfiles_uri);
+  });
 });

--- a/dotfiles/main.tf
+++ b/dotfiles/main.tf
@@ -14,11 +14,17 @@ variable "agent_id" {
   description = "The ID of a Coder agent."
 }
 
+variable "default_dotfiles_uri" {
+  type        = string
+  description = "The default dotfiles URI if the workspace user does not provide one."
+  default     = ""
+}
+
 data "coder_parameter" "dotfiles_uri" {
   type         = "string"
   name         = "dotfiles_uri"
   display_name = "Dotfiles URL (optional)"
-  default      = ""
+  default      = var.default_dotfiles_uri
   description  = "Enter a URL for a [dotfiles repository](https://dotfiles.github.io) to personalize your workspace"
   mutable      = true
   icon         = "/icon/dotfiles.svg"
@@ -40,4 +46,9 @@ resource "coder_script" "personalize" {
 output "dotfiles_uri" {
   description = "Dotfiles URI"
   value       = data.coder_parameter.dotfiles_uri.value
+}
+
+output "dotfiles_default_uri" {
+  description = "Dotfiles Default URI"
+  value       = var.default_dotfiles_uri
 }


### PR DESCRIPTION
Regarding https://github.com/coder/modules/issues/218

Provide an option to specify a default Dotfiles repo in the workspace template.

Include test and doc per @michaelbrewer