### PR TITLE
feat(jetbrains-gateway): Allow fetching latest version dynamically

### DIFF
--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "coder/coder"
       version = ">= 0.17"
     }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.0"
+    }
   }
 }
 
@@ -44,6 +48,12 @@ variable "coder_parameter_order" {
   type        = number
   description = "The order determines the position of a template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order)."
   default     = null
+}
+
+variable "latest" {
+  type        = bool
+  description = "Whether to fetch the latest version of the IDE."
+  default     = true
 }
 
 variable "jetbrains_ide_versions" {
@@ -120,6 +130,11 @@ variable "jetbrains_ides" {
   }
 }
 
+data "http" "jetbrains_ide_versions" {
+  for_each = var.latest ? toset(var.jetbrains_ides) : toset([])
+  url      = "https://data.services.jetbrains.com/products/releases?code=${each.key}&latest=true&type=release"
+}
+
 locals {
   jetbrains_ides = {
     "GO" = {
@@ -128,6 +143,7 @@ locals {
       identifier    = "GO",
       build_number  = var.jetbrains_ide_versions["GO"].build_number,
       download_link = "https://download.jetbrains.com/go/goland-${var.jetbrains_ide_versions["GO"].version}.tar.gz"
+      version       = var.jetbrains_ide_versions["GO"].version
     },
     "WS" = {
       icon          = "/icon/webstorm.svg",
@@ -135,6 +151,7 @@ locals {
       identifier    = "WS",
       build_number  = var.jetbrains_ide_versions["WS"].build_number,
       download_link = "https://download.jetbrains.com/webstorm/WebStorm-${var.jetbrains_ide_versions["WS"].version}.tar.gz"
+      version       = var.jetbrains_ide_versions["WS"].version
     },
     "IU" = {
       icon          = "/icon/intellij.svg",
@@ -142,6 +159,7 @@ locals {
       identifier    = "IU",
       build_number  = var.jetbrains_ide_versions["IU"].build_number,
       download_link = "https://download.jetbrains.com/idea/ideaIU-${var.jetbrains_ide_versions["IU"].version}.tar.gz"
+      version       = var.jetbrains_ide_versions["IU"].version
     },
     "PY" = {
       icon          = "/icon/pycharm.svg",
@@ -149,6 +167,7 @@ locals {
       identifier    = "PY",
       build_number  = var.jetbrains_ide_versions["PY"].build_number,
       download_link = "https://download.jetbrains.com/python/pycharm-professional-${var.jetbrains_ide_versions["PY"].version}.tar.gz"
+      version       = var.jetbrains_ide_versions["PY"].version
     },
     "CL" = {
       icon          = "/icon/clion.svg",
@@ -156,6 +175,7 @@ locals {
       identifier    = "CL",
       build_number  = var.jetbrains_ide_versions["CL"].build_number,
       download_link = "https://download.jetbrains.com/cpp/CLion-${var.jetbrains_ide_versions["CL"].version}.tar.gz"
+      version       = var.jetbrains_ide_versions["CL"].version
     },
     "PS" = {
       icon          = "/icon/phpstorm.svg",
@@ -163,6 +183,7 @@ locals {
       identifier    = "PS",
       build_number  = var.jetbrains_ide_versions["PS"].build_number,
       download_link = "https://download.jetbrains.com/webide/PhpStorm-${var.jetbrains_ide_versions["PS"].version}.tar.gz"
+      version       = var.jetbrains_ide_versions["PS"].version
     },
     "RM" = {
       icon          = "/icon/rubymine.svg",
@@ -170,6 +191,7 @@ locals {
       identifier    = "RM",
       build_number  = var.jetbrains_ide_versions["RM"].build_number,
       download_link = "https://download.jetbrains.com/ruby/RubyMine-${var.jetbrains_ide_versions["RM"].version}.tar.gz"
+      version       = var.jetbrains_ide_versions["RM"].version
     }
     "RD" = {
       icon          = "/icon/rider.svg",
@@ -177,8 +199,18 @@ locals {
       identifier    = "RD",
       build_number  = var.jetbrains_ide_versions["RD"].build_number,
       download_link = "https://download.jetbrains.com/rider/JetBrains.Rider-${var.jetbrains_ide_versions["RD"].version}.tar.gz"
+      version       = var.jetbrains_ide_versions["RD"].version
     }
   }
+
+  icon          = try(lookup(local.jetbrains_ides, data.coder_parameter.jetbrains_ide.value).icon, "/icon/gateway.svg")
+  json_data     = var.latest ? jsondecode(data.http.jetbrains_ide_versions[data.coder_parameter.jetbrains_ide.value].response_body) : {}
+  key           = var.latest ? keys(local.json_data)[0] : ""
+  display_name  = local.jetbrains_ides[data.coder_parameter.jetbrains_ide.value].name
+  identifier    = data.coder_parameter.jetbrains_ide.value
+  download_link = var.latest ? local.json_data[local.key][0].downloads.linux.link : local.jetbrains_ides[data.coder_parameter.jetbrains_ide.value].download_link
+  build_number  = var.latest ? local.json_data[local.key][0].build : local.jetbrains_ides[data.coder_parameter.jetbrains_ide.value].build_number
+  version       = var.latest ? local.json_data[local.key][0].version : var.jetbrains_ide_versions[data.coder_parameter.jetbrains_ide.value].version
 }
 
 data "coder_parameter" "jetbrains_ide" {
@@ -193,9 +225,9 @@ data "coder_parameter" "jetbrains_ide" {
   dynamic "option" {
     for_each = var.jetbrains_ides
     content {
-      icon  = lookup(local.jetbrains_ides, option.value).icon
-      name  = lookup(local.jetbrains_ides, option.value).name
-      value = lookup(local.jetbrains_ides, option.value).identifier
+      icon  = local.jetbrains_ides[option.value].icon
+      name  = local.jetbrains_ides[option.value].name
+      value = option.value
     }
   }
 }
@@ -205,8 +237,8 @@ data "coder_workspace" "me" {}
 resource "coder_app" "gateway" {
   agent_id     = var.agent_id
   slug         = "gateway"
-  display_name = try(lookup(local.jetbrains_ides, data.coder_parameter.jetbrains_ide.value).name, "JetBrains IDE")
-  icon         = try(lookup(local.jetbrains_ides, data.coder_parameter.jetbrains_ide.value).icon, "/icon/gateway.svg")
+  display_name = try(lookup(data.coder_parameter.jetbrains_ide.option, data.coder_parameter.jetbrains_ide.value).name, "JetBrains IDE")
+  icon         = try(lookup(data.coder_parameter.jetbrains_ide.option, data.coder_parameter.jetbrains_ide.value).icon, "/icon/gateway.svg")
   external     = true
   order        = var.order
   url = join("", [
@@ -221,36 +253,36 @@ resource "coder_app" "gateway" {
     "&token=",
     "$SESSION_TOKEN",
     "&ide_product_code=",
-    local.jetbrains_ides[data.coder_parameter.jetbrains_ide.value].identifier,
+    data.coder_parameter.jetbrains_ide.value,
     "&ide_build_number=",
-    local.jetbrains_ides[data.coder_parameter.jetbrains_ide.value].build_number,
+    local.build_number,
     "&ide_download_link=",
-    local.jetbrains_ides[data.coder_parameter.jetbrains_ide.value].download_link
+    local.download_link,
   ])
 }
 
 output "identifier" {
-  value = data.coder_parameter.jetbrains_ide.value
+  value = local.identifier
 }
 
-output "name" {
-  value = coder_app.gateway.display_name
+output "display_name" {
+  value = local.display_name
 }
 
 output "icon" {
-  value = coder_app.gateway.icon
+  value = local.icon
 }
 
 output "download_link" {
-  value = lookup(local.jetbrains_ides, data.coder_parameter.jetbrains_ide.value).download_link
+  value = local.download_link
 }
 
 output "build_number" {
-  value = lookup(local.jetbrains_ides, data.coder_parameter.jetbrains_ide.value).build_number
+  value = local.build_number
 }
 
 output "version" {
-  value = var.jetbrains_ide_versions[data.coder_parameter.jetbrains_ide.value].version
+  value = local.version
 }
 
 output "url" {

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -53,7 +53,7 @@ variable "coder_parameter_order" {
 variable "latest" {
   type        = bool
   description = "Whether to fetch the latest version of the IDE."
-  default     = true
+  default     = false
 }
 
 variable "channel" {
@@ -61,7 +61,7 @@ variable "channel" {
   description = "JetBrains IDE release channel. Valid values are release and eap."
   default     = "release"
   validation {
-    condition     = can(regex("^(?:release|eap)$", var.channel))
+    condition     = can(regex("^(release|eap)$", var.channel))
     error_message = "The channel must be either release or eap."
   }
 }

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -56,6 +56,16 @@ variable "latest" {
   default     = true
 }
 
+variable "channel" {
+  type        = string
+  description = "The channel to fetch the IDE version from."
+  default     = "release"
+  validation {
+    condition     = can(regex("^(?:release|eap)$", var.channel))
+    error_message = "The channel must be either release or eap."
+  }
+}
+
 variable "jetbrains_ide_versions" {
   type = map(object({
     build_number = string
@@ -132,7 +142,7 @@ variable "jetbrains_ides" {
 
 data "http" "jetbrains_ide_versions" {
   for_each = var.latest ? toset(var.jetbrains_ides) : toset([])
-  url      = "https://data.services.jetbrains.com/products/releases?code=${each.key}&latest=true&type=release"
+  url      = "https://data.services.jetbrains.com/products/releases?code=${each.key}&latest=true&type=${var.channel}"
 }
 
 locals {

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -58,7 +58,7 @@ variable "latest" {
 
 variable "channel" {
   type        = string
-  description = "The channel to fetch the IDE version from."
+  description = "JetBrains IDE release channel. Valid values are release and eap."
   default     = "release"
   validation {
     condition     = can(regex("^(?:release|eap)$", var.channel))


### PR DESCRIPTION
This pull request adds the ability to fetch the JetBrains IDE's latest version dynamically. It adds a new variable to fetch the latest version. The `data.http.jetbrains_ide_versions` data source retrieves the latest version information.

TODO: Add tests (probably in a separate PR)

Closes #217