### PR TITLE
feat(code-server): auto install extensions

### DIFF
--- a/code-server/main.tf
+++ b/code-server/main.tf
@@ -101,6 +101,12 @@ variable "extensions_dir" {
   default     = ""
 }
 
+variable "auto_install_extensions" {
+  type        = bool
+  description = "Automatically install recommended extensions when code-server starts."
+  default     = false
+}
+
 resource "coder_script" "code-server" {
   agent_id     = var.agent_id
   display_name = "code-server"
@@ -117,6 +123,8 @@ resource "coder_script" "code-server" {
     OFFLINE : var.offline,
     USE_CACHED : var.use_cached,
     EXTENSIONS_DIR : var.extensions_dir,
+    FOLDER : var.folder,
+    AUTO_INSTALL_EXTENSIONS : var.auto_install_extensions,
   })
   run_on_start = true
 

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -70,4 +70,24 @@ for extension in "$${EXTENSIONLIST[@]}"; do
   fi
 done
 
+if [ "${AUTO_INSTALL_EXTENSIONS}" = true ]; then
+  WORKSPACE_DIR="$HOME/"
+  if [ -n "${FOLDER}" ]; then
+    WORKSPACE_DIR="${FOLDER}"
+  fi
+
+  if ! command -v jq > /dev/null; then
+    echo "jq is required to install extensions from a workspace file."
+    exit 0
+  fi
+
+  if [ -f "$WORKSPACE_DIR/.vscode/extensions.json" ]; then
+    printf "🧩 Installing extensions from %s/.vscode/extensions.json...\n" "$WORKSPACE_DIR"
+    extensions=$(jq -r '.recommendations[]' "$WORKSPACE_DIR"/.vscode/extensions.json)
+    for extension in $extensions; do
+      $CODE_SERVER "$EXTENSION_ARG" --install-extension "$extension"
+    done
+  fi
+fi
+
 run_code_server


### PR DESCRIPTION
Add a new flag `auto_install_extensions` which auto installed the recommended extensions found in `.vscode/extensions.json`

```tf
module "code-server" {
 source                   = "registry.coder.com/modules/code-server/coder"
  version                 = "1.0.13"
  agent_id                = coder_agent.main.id
  folder                  = "/home/${local.username}/modules"
  install_prefix          = "/home/${local.username}/.code-server"
  extensions_dir          = "/home/${local.username}/.code-server/extensions"
  use_cached              = true
  auto_install_extensions = true
}
```