### PR TITLE
fix(dotfiles): remove extra "(optional)" in coder parameter display name

### DIFF
--- a/dotfiles/main.tf
+++ b/dotfiles/main.tf
@@ -44,7 +44,7 @@ data "coder_parameter" "dotfiles_uri" {
 
   type         = "string"
   name         = "dotfiles_uri"
-  display_name = "Dotfiles URL (optional)"
+  display_name = "Dotfiles URL"
   order        = var.coder_parameter_order
   default      = var.default_dotfiles_uri
   description  = "Enter a URL for a [dotfiles repository](https://dotfiles.github.io) to personalize your workspace"


### PR DESCRIPTION
Fix the title so that "(optional)" is not there twice.

![image](https://github.com/coder/modules/assets/57866459/1f45ddce-f835-4469-af62-66a4def64600)

cc: @matifali 