### PR TITLE
chore: remove usage of deprecated fields coder_workspace.owner_*

### DIFF
--- a/coder-login/main.tf
+++ b/coder-login/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.12"
+      version = ">= 0.23"
     }
   }
 }
@@ -15,11 +15,12 @@ variable "agent_id" {
 }
 
 data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
 
 resource "coder_script" "coder-login" {
   agent_id = var.agent_id
   script = templatefile("${path.module}/run.sh", {
-    CODER_USER_TOKEN : data.coder_workspace.me.owner_session_token,
+    CODER_USER_TOKEN : data.coder_workspace_owner.me.session_token,
     CODER_DEPLOYMENT_URL : data.coder_workspace.me.access_url
   })
   display_name       = "Coder Login"

--- a/git-config/main.test.ts
+++ b/git-config/main.test.ts
@@ -20,9 +20,10 @@ describe("git-config", async () => {
     });
 
     const resources = state.resources;
-    expect(resources).toHaveLength(5);
+    expect(resources).toHaveLength(6);
     expect(resources).toMatchObject([
       { type: "coder_workspace", name: "me" },
+      { type: "coder_workspace_owner", name: "me" },
       { type: "coder_env", name: "git_author_email" },
       { type: "coder_env", name: "git_author_name" },
       { type: "coder_env", name: "git_commmiter_email" },
@@ -37,11 +38,12 @@ describe("git-config", async () => {
     });
 
     const resources = state.resources;
-    expect(resources).toHaveLength(7);
+    expect(resources).toHaveLength(8);
     expect(resources).toMatchObject([
       { type: "coder_parameter", name: "user_email" },
       { type: "coder_parameter", name: "username" },
       { type: "coder_workspace", name: "me" },
+      { type: "coder_workspace_owner", name: "me" },
       { type: "coder_env", name: "git_author_email" },
       { type: "coder_env", name: "git_author_name" },
       { type: "coder_env", name: "git_commmiter_email" },
@@ -61,9 +63,10 @@ describe("git-config", async () => {
     );
 
     const resources = state.resources;
-    expect(resources).toHaveLength(5);
+    expect(resources).toHaveLength(6);
     expect(resources).toMatchObject([
       { type: "coder_workspace", name: "me" },
+      { type: "coder_workspace_owner", name: "me" },
       { type: "coder_env", name: "git_author_email" },
       { type: "coder_env", name: "git_author_name" },
       { type: "coder_env", name: "git_commmiter_email" },
@@ -80,11 +83,12 @@ describe("git-config", async () => {
       coder_parameter_order: order.toString(),
     });
     const resources = state.resources;
-    expect(resources).toHaveLength(7);
+    expect(resources).toHaveLength(8);
     expect(resources).toMatchObject([
       { type: "coder_parameter", name: "user_email" },
       { type: "coder_parameter", name: "username" },
       { type: "coder_workspace", name: "me" },
+      { type: "coder_workspace_owner", name: "me" },
       { type: "coder_env", name: "git_author_email" },
       { type: "coder_env", name: "git_author_name" },
       { type: "coder_env", name: "git_commmiter_email" },
@@ -106,10 +110,11 @@ describe("git-config", async () => {
       coder_parameter_order: order.toString(),
     });
     const resources = state.resources;
-    expect(resources).toHaveLength(6);
+    expect(resources).toHaveLength(7);
     expect(resources).toMatchObject([
       { type: "coder_parameter", name: "username" },
       { type: "coder_workspace", name: "me" },
+      { type: "coder_workspace_owner", name: "me" },
       { type: "coder_env", name: "git_author_email" },
       { type: "coder_env", name: "git_author_name" },
       { type: "coder_env", name: "git_commmiter_email" },

--- a/git-config/main.tf
+++ b/git-config/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.22"
+      version = ">= 0.23"
     }
   }
 }
@@ -33,6 +33,7 @@ variable "coder_parameter_order" {
 }
 
 data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
 
 data "coder_parameter" "user_email" {
   count        = var.allow_email_change ? 1 : 0
@@ -59,25 +60,25 @@ data "coder_parameter" "username" {
 resource "coder_env" "git_author_name" {
   agent_id = var.agent_id
   name     = "GIT_AUTHOR_NAME"
-  value    = coalesce(try(data.coder_parameter.username[0].value, ""), data.coder_workspace.me.owner_name, data.coder_workspace.me.owner)
+  value    = coalesce(try(data.coder_parameter.username[0].value, ""), data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
 }
 
 resource "coder_env" "git_commmiter_name" {
   agent_id = var.agent_id
   name     = "GIT_COMMITTER_NAME"
-  value    = coalesce(try(data.coder_parameter.username[0].value, ""), data.coder_workspace.me.owner_name, data.coder_workspace.me.owner)
+  value    = coalesce(try(data.coder_parameter.username[0].value, ""), data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
 }
 
 resource "coder_env" "git_author_email" {
   agent_id = var.agent_id
   name     = "GIT_AUTHOR_EMAIL"
-  value    = coalesce(try(data.coder_parameter.user_email[0].value, ""), data.coder_workspace.me.owner_email)
-  count    = data.coder_workspace.me.owner_email != "" ? 1 : 0
+  value    = coalesce(try(data.coder_parameter.user_email[0].value, ""), data.coder_workspace_owner.me.email)
+  count    = data.coder_workspace_owner.me.email != "" ? 1 : 0
 }
 
 resource "coder_env" "git_commmiter_email" {
   agent_id = var.agent_id
   name     = "GIT_COMMITTER_EMAIL"
-  value    = coalesce(try(data.coder_parameter.user_email[0].value, ""), data.coder_workspace.me.owner_email)
-  count    = data.coder_workspace.me.owner_email != "" ? 1 : 0
+  value    = coalesce(try(data.coder_parameter.user_email[0].value, ""), data.coder_workspace_owner.me.email)
+  count    = data.coder_workspace_owner.me.email != "" ? 1 : 0
 }

--- a/github-upload-public-key/main.tf
+++ b/github-upload-public-key/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.12"
+      version = ">= 0.23"
     }
   }
 }
@@ -27,11 +27,12 @@ variable "github_api_url" {
 }
 
 data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
 
 resource "coder_script" "github_upload_public_key" {
   agent_id = var.agent_id
   script = templatefile("${path.module}/run.sh", {
-    CODER_OWNER_SESSION_TOKEN : data.coder_workspace.me.owner_session_token,
+    CODER_OWNER_SESSION_TOKEN : data.coder_workspace_owner.me.session_token,
     CODER_ACCESS_URL : data.coder_workspace.me.access_url,
     CODER_EXTERNAL_AUTH_ID : var.external_auth_id,
     GITHUB_API_URL : var.github_api_url,

--- a/jfrog-oauth/main.tf
+++ b/jfrog-oauth/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.12.4"
+      version = ">= 0.23"
     }
   }
 }
@@ -68,11 +68,12 @@ EOF
 
 locals {
   # The username field to use for artifactory
-  username   = var.username_field == "email" ? data.coder_workspace.me.owner_email : data.coder_workspace.me.owner
+  username   = var.username_field == "email" ? data.coder_workspace_owner.me.email : data.coder_workspace_owner.me.name
   jfrog_host = replace(var.jfrog_url, "https://", "")
 }
 
 data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
 
 data "coder_external_auth" "jfrog" {
   id = var.external_auth_id
@@ -87,7 +88,7 @@ resource "coder_script" "jfrog" {
     JFROG_HOST : local.jfrog_host,
     JFROG_SERVER_ID : var.jfrog_server_id,
     ARTIFACTORY_USERNAME : local.username,
-    ARTIFACTORY_EMAIL : data.coder_workspace.me.owner_email,
+    ARTIFACTORY_EMAIL : data.coder_workspace_owner.me.email,
     ARTIFACTORY_ACCESS_TOKEN : data.coder_external_auth.jfrog.access_token,
     CONFIGURE_CODE_SERVER : var.configure_code_server,
     REPOSITORY_NPM : lookup(var.package_managers, "npm", ""),

--- a/jfrog-token/README.md
+++ b/jfrog-token/README.md
@@ -98,7 +98,7 @@ module "jfrog" {
   agent_id                 = coder_agent.example.id
   jfrog_url                = "https://XXXX.jfrog.io"
   artifactory_access_token = var.artifactory_access_token
-  token_description        = "Token for Coder workspace: ${data.coder_workspace.me.owner}/${data.coder_workspace.me.name}"
+  token_description        = "Token for Coder workspace: ${data.coder_workspace_owner.me.name}/${data.coder_workspace.me.name}"
   package_managers = {
     "npm" : "npm",
     "go" : "go",

--- a/jfrog-token/main.tf
+++ b/jfrog-token/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.12.4"
+      version = ">= 0.23"
     }
     artifactory = {
       source  = "registry.terraform.io/jfrog/artifactory"
@@ -95,7 +95,7 @@ EOF
 
 locals {
   # The username field to use for artifactory
-  username   = var.username_field == "email" ? data.coder_workspace.me.owner_email : data.coder_workspace.me.owner
+  username   = var.username_field == "email" ? data.coder_workspace_owner.me.email : data.coder_workspace_owner.me.name
   jfrog_host = replace(var.jfrog_url, "https://", "")
 }
 
@@ -117,6 +117,7 @@ resource "artifactory_scoped_token" "me" {
 }
 
 data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
 
 resource "coder_script" "jfrog" {
   agent_id     = var.agent_id
@@ -127,7 +128,7 @@ resource "coder_script" "jfrog" {
     JFROG_HOST : local.jfrog_host,
     JFROG_SERVER_ID : var.jfrog_server_id,
     ARTIFACTORY_USERNAME : local.username,
-    ARTIFACTORY_EMAIL : data.coder_workspace.me.owner_email,
+    ARTIFACTORY_EMAIL : data.coder_workspace_owner.me.email,
     ARTIFACTORY_ACCESS_TOKEN : artifactory_scoped_token.me.access_token,
     CONFIGURE_CODE_SERVER : var.configure_code_server,
     REPOSITORY_NPM : lookup(var.package_managers, "npm", ""),

--- a/vscode-desktop/main.test.ts
+++ b/vscode-desktop/main.test.ts
@@ -21,7 +21,9 @@ describe("vscode-desktop", async () => {
       "vscode://coder.coder-remote/open?owner=default&workspace=default&url=https://mydeployment.coder.com&token=$SESSION_TOKEN",
     );
 
-    const coder_app = state.resources.find((res) => res.type == "coder_app" && res.name == "vscode");
+    const coder_app = state.resources.find(
+      (res) => res.type == "coder_app" && res.name == "vscode",
+    );
     expect(coder_app).not.toBeNull();
     expect(coder_app.instances.length).toBe(1);
     expect(coder_app.instances[0].attributes.order).toBeNull();
@@ -75,7 +77,9 @@ describe("vscode-desktop", async () => {
       order: "22",
     });
 
-    const coder_app = state.resources.find((res) => res.type == "coder_app" && res.name == "vscode");
+    const coder_app = state.resources.find(
+      (res) => res.type == "coder_app" && res.name == "vscode",
+    );
     expect(coder_app).not.toBeNull();
     expect(coder_app.instances.length).toBe(1);
     expect(coder_app.instances[0].attributes.order).toBe(22);

--- a/vscode-desktop/main.test.ts
+++ b/vscode-desktop/main.test.ts
@@ -21,8 +21,10 @@ describe("vscode-desktop", async () => {
       "vscode://coder.coder-remote/open?owner=default&workspace=default&url=https://mydeployment.coder.com&token=$SESSION_TOKEN",
     );
 
-    const resources: any = state.resources;
-    expect(resources[1].instances[0].attributes.order).toBeNull();
+    const coder_app = state.resources.find((res) => res.type == "coder_app" && res.name == "vscode");
+    expect(coder_app).not.toBeNull();
+    expect(coder_app.instances.length).toBe(1);
+    expect(coder_app.instances[0].attributes.order).toBeNull();
   });
 
   it("adds folder", async () => {
@@ -73,7 +75,9 @@ describe("vscode-desktop", async () => {
       order: "22",
     });
 
-    const resources: any = state.resources;
-    expect(resources[1].instances[0].attributes.order).toBe(22);
+    const coder_app = state.resources.find((res) => res.type == "coder_app" && res.name == "vscode");
+    expect(coder_app).not.toBeNull();
+    expect(coder_app.instances.length).toBe(1);
+    expect(coder_app.instances[0].attributes.order).toBe(22);
   });
 });

--- a/vscode-desktop/main.tf
+++ b/vscode-desktop/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.17"
+      version = ">= 0.23"
     }
   }
 }
@@ -33,6 +33,7 @@ variable "order" {
 }
 
 data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
 
 resource "coder_app" "vscode" {
   agent_id     = var.agent_id
@@ -44,7 +45,7 @@ resource "coder_app" "vscode" {
   url = join("", [
     "vscode://coder.coder-remote/open",
     "?owner=",
-    data.coder_workspace.me.owner,
+    data.coder_workspace_owner.me.name,
     "&workspace=",
     data.coder_workspace.me.name,
     var.folder != "" ? join("", ["&folder=", var.folder]) : "",


### PR DESCRIPTION
Updates the following modules to no longer reference fields matching coder_workspace.owner_*:
- coder-login
- git-config
- github-upload-public-key
- jfrog-oauth
- vscode-desktop

Also updates dependency of coder/coder to 0.23.0 for the above.

For context, see https://github.com/coder/terraform-provider-coder/releases/tag/v0.23.0

Also closes #255