### PR TITLE
feat(code-server): skip extension if installed

### DIFF
--- a/code-server/main.tf
+++ b/code-server/main.tf
@@ -95,6 +95,12 @@ variable "use_cached" {
   default     = false
 }
 
+variable "use_cached_extensions" {
+  type        = bool
+  description = "Uses cached copy of extensions, otherwise do a forced upgrade"
+  default     = false
+}
+
 variable "extensions_dir" {
   type        = string
   description = "Override the directory to store extensions in."
@@ -122,6 +128,7 @@ resource "coder_script" "code-server" {
     SETTINGS : replace(jsonencode(var.settings), "\"", "\\\""),
     OFFLINE : var.offline,
     USE_CACHED : var.use_cached,
+    USE_CACHED_EXTENSIONS : var.use_cached_extensions,
     EXTENSIONS_DIR : var.extensions_dir,
     FOLDER : var.folder,
     AUTO_INSTALL_EXTENSIONS : var.auto_install_extensions,

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -19,7 +19,7 @@ function run_code_server() {
 }
 
 function extension_installed() {
-  if [ "${USE_CACHED}" != true ]; then
+  if [ "${USE_CACHED_EXTENSIONS}" != true ]; then
     return 1
   fi
   if [ -z "${EXTENSIONS_DIR}" ]; then
@@ -89,7 +89,7 @@ for extension in "$${EXTENSIONLIST[@]}"; do
     continue
   fi
   printf "🧩 Installing extension $${CODE}$extension$${RESET}...\n"
-  output=$($CODE_SERVER "$EXTENSION_ARG" --install-extension "$extension")
+  output=$($CODE_SERVER "$EXTENSION_ARG" --force --install-extension "$extension")
   if [ $? -ne 0 ]; then
     echo "Failed to install extension: $extension: $output"
     exit 1
@@ -114,7 +114,7 @@ if [ "${AUTO_INSTALL_EXTENSIONS}" = true ]; then
       if extension_installed "$extension"; then
         continue
       fi
-      $CODE_SERVER "$EXTENSION_ARG" --install-extension "$extension"
+      $CODE_SERVER "$EXTENSION_ARG" --force --install-extension "$extension"
     done
   fi
 fi

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -29,11 +29,15 @@ function extension_installed() {
   if [ ! -f "$EXTENSIONS_FILE" ]; then
     return 1
   fi
-  if grep -q "\"$1\"" "$EXTENSIONS_FILE"; then
-    echo "Extension $1 was found in $EXTENSIONS_FILE."
-    return 0
+  if ! command -v grep > /dev/null; then
+    return 1
   fi
-  return 1
+  if ! grep -q "\"$1\"" "$EXTENSIONS_FILE"; then
+    return 1
+  fi
+
+  echo "Extension $1 was found in $EXTENSIONS_FILE."
+  return 0
 }
 
 # Check if the settings file exists...

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -19,6 +19,9 @@ function run_code_server() {
 }
 
 function extension_installed() {
+  if [ "${USE_CACHED}" != true ]; then
+    return 1
+  fi
   if [ -z "${EXTENSIONS_DIR}" ]; then
     return 1
   fi

--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -66,6 +66,7 @@ function extension_installed() {
   fi
   for _extension in "$${EXTENSIONS_ARRAY[@]}"; do
     if [ "$_extension" == "$1" ]; then
+      echo "Extension $1 was already installed."
       return 0
     fi
   done


### PR DESCRIPTION
To aid faster restarts of workspace with extensions already cached, this change will skip if an extension was already installed.

Before change, extensions would be try to be installed, but this operation can be slow, also extensions are not upgraded

<img width="1242" alt="Screenshot 2024-06-08 at 11 47 54 PM" src="https://github.com/coder/modules/assets/5442469/3f8f5679-138e-4eb7-a757-e3c7dbe09d11">

After change with `use_cached_extensions` set, extensions that are already installed are skipped

```tf
module "code-server" {
  source                  = "registry.coder.com/modules/code-server/coder"
  version                 = "1.0.15"
  agent_id                = coder_agent.main.id
  order                   = 1
  folder                  = "/home/${local.username}/modules"
  install_prefix          = "/home/${local.username}/.code-server"
  use_cached              = true
  auto_install_extensions = true
  extensions              = [
    "dracula-theme.theme-dracula"
  ]
  use_cached_extensions   = true
  extensions_dir          = "/home/${local.username}/.code-server/extensions"
}
```

<img width="1254" alt="Screenshot 2024-06-10 at 10 34 22 PM" src="https://github.com/coder/modules/assets/5442469/3e24a8c8-4953-46b5-b4e5-df7f95748cd4">

This change only impacts when `use_cached_extensions` and `extensions_dir` are set. 

--- 

Otherwise on restarts, `--force` is used to ensure existing extensions are upgraded.

<img width="1266" alt="Screenshot 2024-06-10 at 10 32 36 PM" src="https://github.com/coder/modules/assets/5442469/51c30060-f51e-45e9-adcc-08ed4789ad64">


