### PR TITLE
fix: update SVG icon URL for RDP module

### DIFF
--- a/windows-rdp/main.tf
+++ b/windows-rdp/main.tf
@@ -56,7 +56,7 @@ resource "coder_app" "windows-rdp" {
   slug         = "web-rdp"
   display_name = "Web RDP"
   url          = "http://localhost:7171"
-  icon         = "https://svgur.com/i/158F.svg"
+  icon         = "/icon/desktop.svg"
   subdomain    = true
 
   healthcheck {


### PR DESCRIPTION
Addendum to #262
Accidentally missed one of the URLs before merging the main module.