### PR TITLE
fix url schema for webrdp example

### DIFF
--- a/windows-rdp/README.md
+++ b/windows-rdp/README.md
@@ -32,7 +32,7 @@ module "windows_rdp" {
 
 ```tf
 module "windows_rdp" {
-  source      = "registry.coder.com/coder/module/windows-rdp"
+  source      = "registry.coder.com/modules/windows-rdp/coder"
   version     = "1.0.16"
   count       = data.coder_workspace.me.start_count
   agent_id    = resource.coder_agent.main.id
@@ -44,7 +44,7 @@ module "windows_rdp" {
 
 ```tf
 module "windows_rdp" {
-  source      = "registry.coder.com/coder/module/windows-rdp"
+  source      = "registry.coder.com/modules/windows-rdp/coder"
   version     = "1.0.16"
   count       = data.coder_workspace.me.start_count
   agent_id    = resource.coder_agent.main.id


### PR DESCRIPTION
Tested the corrected URL on dogfood.

Was

```tf
module "windows_rdp" {
  source      = "registry.coder.com/coder/module/windows-rdp"
  ...
}
```

Now

```tf
module "windows_rdp" {
  source      = "registry.coder.com/modules/windows-rdp/coder"
  ...
}
```