### PR TITLE
fix(code-server): handle when the extension folder does not exist yet

### DIFF
--- a/code-server/run.sh
+++ b/code-server/run.sh
@@ -10,6 +10,7 @@ CODE_SERVER="${INSTALL_PREFIX}/bin/code-server"
 EXTENSION_ARG=""
 if [ -n "${EXTENSIONS_DIR}" ]; then
   EXTENSION_ARG="--extensions-dir=${EXTENSIONS_DIR}"
+  mkdir -p "${EXTENSIONS_DIR}"
 fi
 
 function run_code_server() {


### PR DESCRIPTION
Preemptively create specified extension folder in case the parent folder is missing. 

So for example is `/home/local/.ws` was not created yet and the extension path is `/home/local/.ws/extensions` then code server will have the following error.

```bash
Error: ENOENT: no such file or directory, mkdir '/home/local/.ws/extensions'
    at Object.mkdirSync (node:fs:1380:26)
    at /home/local/.code-server/lib/code-server-4.91.1/lib/vscode/out/vs/server/node/server.main.js:221:1910
    at Array.forEach ()
    at h (/home/local/.code-server/lib/code-server-4.91.1/lib/vscode/out/vs/server/node/server.main.js:221:1875)
    at m (/home/local/.code-server/lib/code-server-4.91.1/lib/vscode/out/vs/server/node/server.main.js:221:2001)
    at /home/local/.code-server/lib/code-server-4.91.1/out/node/main.js:42:15
    at Generator.next ()
    at fulfilled (/home/local/.code-server/lib/code-server-4.91.1/out/node/main.js:5:58) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'mkdir',
  path: '/home/local/.ws/extensions'
}
```