### PR TITLE
feat(filebrowser): support subdomain = false

### DIFF
--- a/filebrowser/README.md
+++ b/filebrowser/README.md
@@ -44,3 +44,16 @@ module "filebrowser" {
   database_path = ".config/filebrowser.db"
 }
 ```
+
+### Serve from the same domain (no subdomain)
+
+Make sure to set both workspace_name and owner_name.
+
+```tf
+module "filebrowser" {
+  source         = "registry.coder.com/modules/filebrowser/coder"
+  agent_id       = coder_agent.main.id
+  workspace_name = data.coder_workspace.me.name
+  owner_name     = data.coder_workspace_owner.me.name
+}
+```

--- a/filebrowser/README.md
+++ b/filebrowser/README.md
@@ -47,13 +47,11 @@ module "filebrowser" {
 
 ### Serve from the same domain (no subdomain)
 
-Make sure to set both workspace_name and owner_name.
-
 ```tf
 module "filebrowser" {
-  source         = "registry.coder.com/modules/filebrowser/coder"
-  agent_id       = coder_agent.main.id
-  workspace_name = data.coder_workspace.me.name
-  owner_name     = data.coder_workspace_owner.me.name
+  source     = "registry.coder.com/modules/filebrowser/coder"
+  agent_id   = coder_agent.main.id
+  subdomain  = false
+  agent_name = "main"
 }
 ```

--- a/filebrowser/README.md
+++ b/filebrowser/README.md
@@ -13,9 +13,10 @@ A file browser for your workspace.
 
 ```tf
 module "filebrowser" {
-  source   = "registry.coder.com/modules/filebrowser/coder"
-  version  = "1.0.8"
-  agent_id = coder_agent.example.id
+  source     = "registry.coder.com/modules/filebrowser/coder"
+  version    = "1.0.8"
+  agent_id   = coder_agent.example.id
+  agent_name = "main"
 }
 ```
 
@@ -27,10 +28,11 @@ module "filebrowser" {
 
 ```tf
 module "filebrowser" {
-  source   = "registry.coder.com/modules/filebrowser/coder"
-  version  = "1.0.8"
-  agent_id = coder_agent.example.id
-  folder   = "/home/coder/project"
+  source     = "registry.coder.com/modules/filebrowser/coder"
+  version    = "1.0.8"
+  agent_id   = coder_agent.example.id
+  agent_name = "main"
+  folder     = "/home/coder/project"
 }
 ```
 
@@ -41,6 +43,7 @@ module "filebrowser" {
   source        = "registry.coder.com/modules/filebrowser/coder"
   version       = "1.0.8"
   agent_id      = coder_agent.example.id
+  agent_name    = "main"
   database_path = ".config/filebrowser.db"
 }
 ```
@@ -50,8 +53,8 @@ module "filebrowser" {
 ```tf
 module "filebrowser" {
   source     = "registry.coder.com/modules/filebrowser/coder"
-  agent_id   = coder_agent.main.id
-  subdomain  = false
+  agent_id   = coder_agent.example.id
   agent_name = "main"
+  subdomain  = false
 }
 ```

--- a/filebrowser/main.test.ts
+++ b/filebrowser/main.test.ts
@@ -11,11 +11,13 @@ describe("filebrowser", async () => {
 
   testRequiredVariables(import.meta.dir, {
     agent_id: "foo",
+    agent_name: "main",
   });
 
   it("fails with wrong database_path", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",
+      agent_name: "main",
       database_path: "nofb",
     }).catch((e) => {
       if (!e.message.startsWith("\nError: Invalid value for variable")) {
@@ -27,6 +29,7 @@ describe("filebrowser", async () => {
   it("runs with default", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",
+      agent_name: "main",
     });
     const output = await executeScriptInContainer(state, "alpine");
     expect(output.exitCode).toBe(0);
@@ -48,6 +51,7 @@ describe("filebrowser", async () => {
   it("runs with database_path var", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",
+      agent_name: "main",
       database_path: ".config/filebrowser.db",
     });
     const output = await executeScriptInContainer(state, "alpine");
@@ -70,6 +74,7 @@ describe("filebrowser", async () => {
   it("runs with folder var", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",
+      agent_name: "main",
       folder: "/home/coder/project",
     });
     const output = await executeScriptInContainer(state, "alpine");
@@ -92,6 +97,7 @@ describe("filebrowser", async () => {
   it("runs with subdomain=false", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",
+      agent_name: "main",
       subdomain: false,
     });
     const output = await executeScriptInContainer(state, "alpine");

--- a/filebrowser/main.test.ts
+++ b/filebrowser/main.test.ts
@@ -88,4 +88,26 @@ describe("filebrowser", async () => {
       "📝 Logs at /tmp/filebrowser.log",
     ]);
   });
+
+  it("runs with subdomain=false", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      subdomain: false,
+    });
+    const output = await executeScriptInContainer(state, "alpine");
+    expect(output.exitCode).toBe(0);
+    expect(output.stdout).toEqual([
+      "\u001B[0;1mInstalling filebrowser ",
+      "",
+      "🥳 Installation complete! ",
+      "",
+      "👷 Starting filebrowser in background... ",
+      "",
+      "📂 Serving /root at http://localhost:13339 ",
+      "",
+      "Running 'filebrowser --noauth --root /root --port 13339' ",
+      "",
+      "📝 Logs at /tmp/filebrowser.log",
+    ]);
+  });
 });

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -14,10 +14,8 @@ variable "agent_id" {
   description = "The ID of a Coder agent."
 }
 
-variable "workspace_name" {
-  type = string
-  default = ""
-  description = "Set this and owner_name to serve filebrowser from subdirectory."
+data "coder_workspace" "me" {
+  count = var.subdomain
 }
 
 variable "owner_name" {

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -97,7 +97,7 @@ resource "coder_app" "filebrowser" {
   agent_id     = var.agent_id
   slug         = "filebrowser"
   display_name = "File Browser"
-  url          = "http://localhost:${var.port}"
+  url          = "http://localhost:${var.port}/files"
   icon         = "https://raw.githubusercontent.com/filebrowser/logo/master/icon_raw.svg"
   subdomain    = var.subdomain
   share        = var.share

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -88,7 +88,8 @@ resource "coder_script" "filebrowser" {
     DB_PATH : var.database_path,
     WORKSPACE_NAME : var.workspace_name,
     OWNER_NAME : var.owner_name,
-    RESOURCE_NAME : var.resource_name
+    AGENT_NAME : var.agent_name
+    SUBDOMAIN : var.subdomain
   })
   run_on_start = true
 }

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -100,7 +100,7 @@ resource "coder_app" "filebrowser" {
   display_name = "File Browser"
   url          = "http://localhost:${var.port}"
   icon         = "https://raw.githubusercontent.com/filebrowser/logo/master/icon_raw.svg"
-  subdomain    = var.owner_name == "" && var.workspace_name == ""
+  subdomain    = var.subdomain
   share        = var.share
   order        = var.order
 }

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -14,6 +14,24 @@ variable "agent_id" {
   description = "The ID of a Coder agent."
 }
 
+variable "workspace_name" {
+  type = string
+  default = ""
+  description = "Set this and owner_name to serve filebrowser from subdirectory."
+}
+
+variable "owner_name" {
+  type = string
+  default = ""
+  description = "Set this and workspace_name to serve filebrowser from subdirectory."
+}
+
+variable "resource_name" {
+  type = string
+  default = "main"
+  description = "The name of the main deployment. (Used to build the subdirectory of the module.)"
+}
+
 variable "database_path" {
   type        = string
   description = "The path to the filebrowser database."
@@ -67,7 +85,10 @@ resource "coder_script" "filebrowser" {
     PORT : var.port,
     FOLDER : var.folder,
     LOG_PATH : var.log_path,
-    DB_PATH : var.database_path
+    DB_PATH : var.database_path,
+    WORKSPACE_NAME : var.workspace_name,
+    OWNER_NAME : var.owner_name,
+    RESOURCE_NAME : var.resource_name
   })
   run_on_start = true
 }
@@ -78,7 +99,7 @@ resource "coder_app" "filebrowser" {
   display_name = "File Browser"
   url          = "http://localhost:${var.port}"
   icon         = "https://raw.githubusercontent.com/filebrowser/logo/master/icon_raw.svg"
-  subdomain    = true
+  subdomain    = var.owner_name == "" && var.workspace_name == ""
   share        = var.share
   order        = var.order
 }

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -97,7 +97,7 @@ resource "coder_app" "filebrowser" {
   agent_id     = var.agent_id
   slug         = "filebrowser"
   display_name = "File Browser"
-  url          = "http://localhost:${var.port}/"
+  url          = "http://localhost:${var.port}"
   icon         = "https://raw.githubusercontent.com/filebrowser/logo/master/icon_raw.svg"
   subdomain    = var.subdomain
   share        = var.share

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -20,7 +20,6 @@ data "coder_workspace_owner" "me" {}
 
 variable "agent_name" {
   type = string
-  default = "main"
   description = "The name of the main deployment. (Used to build the subpath for coder_app.)"
 }
 

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -26,10 +26,10 @@ variable "owner_name" {
   description = "Set this and workspace_name to serve filebrowser from subdirectory."
 }
 
-variable "resource_name" {
+variable "agent_name" {
   type = string
-  default = "main"
-  description = "The name of the main deployment. (Used to build the subdirectory of the module.)"
+  default = ""
+  description = "The name of the main deployment. (Used to build the subpath for coder_app.)"
 }
 
 variable "database_path" {

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -14,13 +14,9 @@ variable "agent_id" {
   description = "The ID of a Coder agent."
 }
 
-data "coder_workspace" "me" {
-  count = var.subdomain
-}
+data "coder_workspace" "me" {}
 
-data "coder_workspace_owner" "me" {
-  count = var.subdomain
-}
+data "coder_workspace_owner" "me" {}
 
 variable "agent_name" {
   type = string

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -20,7 +20,7 @@ data "coder_workspace_owner" "me" {}
 
 variable "agent_name" {
   type = string
-  default = ""
+  default = "main"
   description = "The name of the main deployment. (Used to build the subpath for coder_app.)"
 }
 

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -72,6 +72,15 @@ variable "order" {
   default     = null
 }
 
+variable "subdomain" {
+  type        = bool
+  description = <<-EOT
+    Determines whether the app will be accessed via it's own subdomain or whether it will be accessed via a path on Coder.
+    If wildcards have not been setup by the administrator then apps with "subdomain" set to true will not be accessible.
+  EOT
+  default     = true
+}
+
 resource "coder_script" "filebrowser" {
   agent_id     = var.agent_id
   display_name = "File Browser"

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -97,7 +97,7 @@ resource "coder_app" "filebrowser" {
   agent_id     = var.agent_id
   slug         = "filebrowser"
   display_name = "File Browser"
-  url          = "http://localhost:${var.port}/files"
+  url          = "http://localhost:${var.port}/"
   icon         = "https://raw.githubusercontent.com/filebrowser/logo/master/icon_raw.svg"
   subdomain    = var.subdomain
   share        = var.share

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -83,7 +83,7 @@ resource "coder_script" "filebrowser" {
     LOG_PATH : var.log_path,
     DB_PATH : var.database_path,
     SUBDOMAIN : var.subdomain,
-    SERVER_BASE_PATH : format("/@%s/%s.%s/apps/vscode-web/",
+    SERVER_BASE_PATH : format("/@%s/%s.%s/apps/filebrowser",
     data.coder_workspace_owner.me.name, data.coder_workspace.me.name, var.agent_name),
   })
   run_on_start = true

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -82,10 +82,9 @@ resource "coder_script" "filebrowser" {
     FOLDER : var.folder,
     LOG_PATH : var.log_path,
     DB_PATH : var.database_path,
-    WORKSPACE_NAME : data.coder_workspace.me.name,
-    OWNER_NAME : data.coder_workspace_owner.me.name,
-    AGENT_NAME : var.agent_name
-    SUBDOMAIN : var.subdomain
+    SUBDOMAIN : var.subdomain,
+    SERVER_BASE_PATH : format("/@%s/%s.%s/apps/vscode-web/",
+    data.coder_workspace_owner.me.name, data.coder_workspace.me.name, var.agent_name),
   })
   run_on_start = true
 }

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -83,8 +83,7 @@ resource "coder_script" "filebrowser" {
     LOG_PATH : var.log_path,
     DB_PATH : var.database_path,
     SUBDOMAIN : var.subdomain,
-    SERVER_BASE_PATH : format("/@%s/%s.%s/apps/filebrowser",
-    data.coder_workspace_owner.me.name, data.coder_workspace.me.name, var.agent_name),
+    SERVER_BASE_PATH : var.subdomain ? "" : format("/@%s/%s.%s/apps/filebrowser", data.coder_workspace_owner.me.name, data.coder_workspace.me.name, var.agent_name),
   })
   run_on_start = true
 }

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -19,7 +19,7 @@ data "coder_workspace" "me" {}
 data "coder_workspace_owner" "me" {}
 
 variable "agent_name" {
-  type = string
+  type        = string
   description = "The name of the main deployment. (Used to build the subpath for coder_app.)"
 }
 

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -82,8 +82,8 @@ resource "coder_script" "filebrowser" {
     FOLDER : var.folder,
     LOG_PATH : var.log_path,
     DB_PATH : var.database_path,
-    WORKSPACE_NAME : var.workspace_name,
-    OWNER_NAME : var.owner_name,
+    WORKSPACE_NAME : data.coder_workspace.me.name,
+    OWNER_NAME : data.coder_workspace_owner.me.name,
     AGENT_NAME : var.agent_name
     SUBDOMAIN : var.subdomain
   })

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -18,10 +18,8 @@ data "coder_workspace" "me" {
   count = var.subdomain
 }
 
-variable "owner_name" {
-  type = string
-  default = ""
-  description = "Set this and workspace_name to serve filebrowser from subdirectory."
+data "coder_workspace_owner" "me" {
+  count = var.subdomain
 }
 
 variable "agent_name" {

--- a/filebrowser/run.sh
+++ b/filebrowser/run.sh
@@ -17,8 +17,8 @@ if [ "${DB_PATH}" != "filebrowser.db" ]; then
   DB_FLAG=" -d ${DB_PATH}"
 fi
 
-# set baseurl if subdomain = false (owner_name and workspace_name is set), else reset to "" for use with subdomain = true
-if [ "${OWNER_NAME}" != "" ] && [ "${WORKSPACE_NAME}" != "" ]; then
+# set baseurl if subdomain = false
+if [ "${SUBDOMAIN}" == "false" ]; then
   filebrowser config set --baseurl "/@${OWNER_NAME}/${WORKSPACE_NAME}.${RESOURCE_NAME}/apps/filebrowser" > ${LOG_PATH} 2>&1
 else
   filebrowser config set --baseurl "" > ${LOG_PATH} 2>&1

--- a/filebrowser/run.sh
+++ b/filebrowser/run.sh
@@ -17,6 +17,13 @@ if [ "${DB_PATH}" != "filebrowser.db" ]; then
   DB_FLAG=" -d ${DB_PATH}"
 fi
 
+# set baseurl if subdomain = false (owner_name and workspace_name is set), else reset to "" for use with subdomain = true
+if [ "${OWNER_NAME}" != "" ] && [ "${WORKSPACE_NAME}" != "" ]; then
+  filebrowser config set --baseurl "/@${OWNER_NAME}/${WORKSPACE_NAME}.${RESOURCE_NAME}/apps/filebrowser" > ${LOG_PATH} 2>&1
+else
+  filebrowser config set --baseurl "" > ${LOG_PATH} 2>&1
+fi
+
 printf "📂 Serving $${ROOT_DIR} at http://localhost:${PORT} \n\n"
 
 printf "Running 'filebrowser --noauth --root $ROOT_DIR --port ${PORT}$${DB_FLAG}' \n\n"

--- a/filebrowser/run.sh
+++ b/filebrowser/run.sh
@@ -17,12 +17,8 @@ if [ "${DB_PATH}" != "filebrowser.db" ]; then
   DB_FLAG=" -d ${DB_PATH}"
 fi
 
-# set baseurl if subdomain = false
-if [ "${SUBDOMAIN}" == "false" ]; then
-  filebrowser config set --baseurl "${SERVER_BASE_PATH}" > ${LOG_PATH} 2>&1
-else
-  filebrowser config set --baseurl "" > ${LOG_PATH} 2>&1
-fi
+# set baseurl to be able to run if sudomain=false; if subdomain=true the SERVER_BASE_PATH value will be ""
+filebrowser config set --baseurl "${SERVER_BASE_PATH}" > ${LOG_PATH} 2>&1
 
 printf "📂 Serving $${ROOT_DIR} at http://localhost:${PORT} \n\n"
 

--- a/filebrowser/run.sh
+++ b/filebrowser/run.sh
@@ -19,7 +19,7 @@ fi
 
 # set baseurl if subdomain = false
 if [ "${SUBDOMAIN}" == "false" ]; then
-  filebrowser config set --baseurl "/@${OWNER_NAME}/${WORKSPACE_NAME}.${RESOURCE_NAME}/apps/filebrowser" > ${LOG_PATH} 2>&1
+  filebrowser config set --baseurl "${SERVER_BASE_PATH}" > ${LOG_PATH} 2>&1
 else
   filebrowser config set --baseurl "" > ${LOG_PATH} 2>&1
 fi


### PR DESCRIPTION
Resolves #285. 

Add variables `workspace_name`, `owner_name` and `resource_name` to be able to infer the directory the module is served at. Set this directory in the filebrowser app via the `filebrowser config set --baseurl` function.

Added an example to readme.