### PR TITLE
feat(git-clone): custom destination folder name

### DIFF
--- a/git-clone/README.md
+++ b/git-clone/README.md
@@ -153,3 +153,20 @@ module "git-clone" {
   branch_name = "feat/example"
 }
 ```
+
+## Git clone with different destination folder
+
+By default, the repository will be cloned into a folder matching the repository name. You can use the `folder_name` attribute to change the name of the destination folder to something else.
+
+For example, this will clone into the `~/projects/coder/coder-dev` folder:
+
+```tf
+module "git-clone" {
+  source      = "registry.coder.com/modules/git-clone/coder"
+  version     = "1.0.12"
+  agent_id    = coder_agent.example.id
+  url         = "https://github.com/coder/coder"
+  folder_name = "coder-dev"
+  base_dir    = "~/projects/coder"
+}
+```

--- a/git-clone/main.test.ts
+++ b/git-clone/main.test.ts
@@ -79,6 +79,22 @@ describe("git-clone", async () => {
     expect(state.outputs.branch_name.value).toEqual("");
   });
 
+  it("repo_dir should match base_dir/folder_name", async () => {
+    const url = "git@github.com:coder/coder.git";
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      base_dir: "/tmp",
+      folder_name: "foo",
+      url,
+    });
+    expect(state.outputs.repo_dir.value).toEqual("/tmp/foo");
+    expect(state.outputs.folder_name.value).toEqual("foo");
+    expect(state.outputs.clone_url.value).toEqual(url);
+    const https_url = "https://github.com/coder/coder.git";
+    expect(state.outputs.web_url.value).toEqual(https_url);
+    expect(state.outputs.branch_name.value).toEqual("");
+  });
+
   it("branch_name should not include query string", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",

--- a/git-clone/main.tf
+++ b/git-clone/main.tf
@@ -50,7 +50,7 @@ variable "branch_name" {
   default     = ""
 }
 
-variable "dest_dir" {
+variable "folder_name" {
   description = "The destination folder to clone the repository into."
   type        = string
   default     = ""
@@ -70,7 +70,7 @@ locals {
   # Extract the branch name from the URL
   branch_name = var.branch_name == "" && local.tree_path != "" ? replace(replace(local.url, local.clone_url, ""), "/.*${local.tree_path}/", "") : var.branch_name
   # Extract the folder name from the URL
-  folder_name = var.dest_dir == "" ? replace(basename(local.clone_url), ".git", "") : var.dest_dir
+  folder_name = var.folder_name == "" ? replace(basename(local.clone_url), ".git", "") : var.folder_name
   # Construct the path to clone the repository
   clone_path = var.base_dir != "" ? join("/", [var.base_dir, local.folder_name]) : join("/", ["~", local.folder_name])
   # Construct the web URL

--- a/git-clone/main.tf
+++ b/git-clone/main.tf
@@ -50,7 +50,7 @@ variable "branch_name" {
   default     = ""
 }
 
-variable "dest_folder" {
+variable "dest_dir" {
   description = "The destination folder to clone the repository into."
   type        = string
   default     = ""
@@ -70,7 +70,7 @@ locals {
   # Extract the branch name from the URL
   branch_name = var.branch_name == "" && local.tree_path != "" ? replace(replace(local.url, local.clone_url, ""), "/.*${local.tree_path}/", "") : var.branch_name
   # Extract the folder name from the URL
-  folder_name = var.dest_folder == "" ? replace(basename(local.clone_url), ".git", "") : var.dest_folder
+  folder_name = var.dest_dir == "" ? replace(basename(local.clone_url), ".git", "") : var.dest_dir
   # Construct the path to clone the repository
   clone_path = var.base_dir != "" ? join("/", [var.base_dir, local.folder_name]) : join("/", ["~", local.folder_name])
   # Construct the web URL

--- a/git-clone/main.tf
+++ b/git-clone/main.tf
@@ -50,6 +50,12 @@ variable "branch_name" {
   default     = ""
 }
 
+variable "dest_folder" {
+  description = "The destination folder to clone the repository into."
+  type        = string
+  default     = ""
+}
+
 locals {
   # Remove query parameters and fragments from the URL
   url = replace(replace(var.url, "/\\?.*/", ""), "/#.*/", "")
@@ -64,7 +70,7 @@ locals {
   # Extract the branch name from the URL
   branch_name = var.branch_name == "" && local.tree_path != "" ? replace(replace(local.url, local.clone_url, ""), "/.*${local.tree_path}/", "") : var.branch_name
   # Extract the folder name from the URL
-  folder_name = replace(basename(local.clone_url), ".git", "")
+  folder_name = var.dest_folder == "" ? replace(basename(local.clone_url), ".git", "") : var.dest_folder
   # Construct the path to clone the repository
   clone_path = var.base_dir != "" ? join("/", [var.base_dir, local.folder_name]) : join("/", ["~", local.folder_name])
   # Construct the web URL


### PR DESCRIPTION
Currently, repositories are always cloned into a folder named after the repo URL.

For example, if you clone `git@github.com:coder/modules.git`, it'll be cloned into a folder called `modules`.

This PR adds a new attribute, `folder_name`. When provided, this name will be used as the destination folder.

In this example, `coder` will be cloned into `~/projects/coder/coder-dev`, where previously it would've been cloned into `~/projects/coder/coder`:

```tf
module "git-clone" {
  source      = "registry.coder.com/modules/git-clone/coder"
  version     = "1.0.12"
  agent_id    = coder_agent.example.id
  url         = "https://github.com/coder/coder"
  folder_name = "coder-dev"
  base_dir    = "~/projects/coder"
}
```