### PR TITLE
fix(filebrowser): only require agent_name when not on subdomain

### DIFF
--- a/filebrowser/README.md
+++ b/filebrowser/README.md
@@ -13,10 +13,9 @@ A file browser for your workspace.
 
 ```tf
 module "filebrowser" {
-  source     = "registry.coder.com/modules/filebrowser/coder"
-  version    = "1.0.18"
-  agent_id   = coder_agent.example.id
-  agent_name = "main"
+  source   = "registry.coder.com/modules/filebrowser/coder"
+  version  = "1.0.18"
+  agent_id = coder_agent.example.id
 }
 ```
 
@@ -28,11 +27,10 @@ module "filebrowser" {
 
 ```tf
 module "filebrowser" {
-  source     = "registry.coder.com/modules/filebrowser/coder"
-  version    = "1.0.18"
-  agent_id   = coder_agent.example.id
-  agent_name = "main"
-  folder     = "/home/coder/project"
+  source   = "registry.coder.com/modules/filebrowser/coder"
+  version  = "1.0.18"
+  agent_id = coder_agent.example.id
+  folder   = "/home/coder/project"
 }
 ```
 
@@ -43,7 +41,6 @@ module "filebrowser" {
   source        = "registry.coder.com/modules/filebrowser/coder"
   version       = "1.0.18"
   agent_id      = coder_agent.example.id
-  agent_name    = "main"
   database_path = ".config/filebrowser.db"
 }
 ```

--- a/filebrowser/main.test.ts
+++ b/filebrowser/main.test.ts
@@ -11,13 +11,11 @@ describe("filebrowser", async () => {
 
   testRequiredVariables(import.meta.dir, {
     agent_id: "foo",
-    agent_name: "main",
   });
 
   it("fails with wrong database_path", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",
-      agent_name: "main",
       database_path: "nofb",
     }).catch((e) => {
       if (!e.message.startsWith("\nError: Invalid value for variable")) {
@@ -29,7 +27,6 @@ describe("filebrowser", async () => {
   it("runs with default", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",
-      agent_name: "main",
     });
     const output = await executeScriptInContainer(state, "alpine");
     expect(output.exitCode).toBe(0);
@@ -51,7 +48,6 @@ describe("filebrowser", async () => {
   it("runs with database_path var", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",
-      agent_name: "main",
       database_path: ".config/filebrowser.db",
     });
     const output = await executeScriptInContainer(state, "alpine");
@@ -74,7 +70,6 @@ describe("filebrowser", async () => {
   it("runs with folder var", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",
-      agent_name: "main",
       folder: "/home/coder/project",
     });
     const output = await executeScriptInContainer(state, "alpine");

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -23,7 +23,7 @@ variable "agent_name" {
   description = "The name of the main deployment. (Used to build the subpath for coder_app.)"
   default     = ""
   validation {
-    # If subdomain is true, then agent_name must be set.
+    # If subdomain is false, then agent_name must be set.
     condition     = var.subdomain || var.agent_name != ""
     error_message = "The agent_name must be set."
   }

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -24,7 +24,7 @@ variable "agent_name" {
   default     = ""
   validation {
     # If subdomain is true, then agent_name must be set.
-    condition     = var.subdomain ? var.agent_name != "" : true
+    condition     = var.subdomain || var.agent_name != ""
     error_message = "The agent_name must be set."
   }
 }

--- a/filebrowser/main.tf
+++ b/filebrowser/main.tf
@@ -21,6 +21,12 @@ data "coder_workspace_owner" "me" {}
 variable "agent_name" {
   type        = string
   description = "The name of the main deployment. (Used to build the subpath for coder_app.)"
+  default     = ""
+  validation {
+    # If subdomain is true, then agent_name must be set.
+    condition     = var.subdomain ? var.agent_name != "" : true
+    error_message = "The agent_name must be set."
+  }
 }
 
 variable "database_path" {


### PR DESCRIPTION
Ensure that agent_name defaults to an empty string, and introduce
validation to require it when subdomain is true. This aligns with
expected behavior and prevents misconfiguration.