### PR TITLE
chore(cursor): update display_name to Cursor Desktop

### DIFF
--- a/cursor/main.tf
+++ b/cursor/main.tf
@@ -40,7 +40,7 @@ resource "coder_app" "cursor" {
   external     = true
   icon         = "/icon/cursor.svg"
   slug         = "cursor"
-  display_name = "Cursor IDE"
+  display_name = "Cursor Desktop"
   order        = var.order
   url = join("", [
     "cursor://coder.coder-remote/open",


### PR DESCRIPTION
Updates `coder_app`'s display name to Cursor Desktop on @kylecarbs feedback and align with VSCode Desktop.