### PR TITLE
Add owner to Gateway link

### DIFF
--- a/jetbrains-gateway/README.md
+++ b/jetbrains-gateway/README.md
@@ -14,7 +14,7 @@ This module adds a JetBrains Gateway Button to open any workspace with a single 
 ```tf
 module "jetbrains_gateway" {
   source         = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version        = "1.0.13"
+  version        = "1.0.20"
   agent_id       = coder_agent.example.id
   agent_name     = "example"
   folder         = "/home/coder/example"
@@ -32,7 +32,7 @@ module "jetbrains_gateway" {
 ```tf
 module "jetbrains_gateway" {
   source         = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version        = "1.0.13"
+  version        = "1.0.20"
   agent_id       = coder_agent.example.id
   agent_name     = "example"
   folder         = "/home/coder/example"
@@ -46,7 +46,7 @@ module "jetbrains_gateway" {
 ```tf
 module "jetbrains_gateway" {
   source         = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version        = "1.0.13"
+  version        = "1.0.20"
   agent_id       = coder_agent.example.id
   agent_name     = "example"
   folder         = "/home/coder/example"
@@ -61,7 +61,7 @@ module "jetbrains_gateway" {
 ```tf
 module "jetbrains_gateway" {
   source         = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version        = "1.0.13"
+  version        = "1.0.20"
   agent_id       = coder_agent.example.id
   agent_name     = "example"
   folder         = "/home/coder/example"

--- a/jetbrains-gateway/main.test.ts
+++ b/jetbrains-gateway/main.test.ts
@@ -14,6 +14,26 @@ describe("jetbrains-gateway", async () => {
     folder: "/home/foo",
   });
 
+  it("should create a link with the default values", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      // These are all required.
+      agent_id: "foo",
+      agent_name: "foo",
+      folder: "/home/coder",
+    });
+    expect(state.outputs.url.value).toBe(
+      "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&agent=foo&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=241.14494.240&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.1.tar.gz",
+    );
+
+    const coder_app = state.resources.find(
+      (res) => res.type === "coder_app" && res.name === "gateway",
+    );
+
+    expect(coder_app).not.toBeNull();
+    expect(coder_app?.instances.length).toBe(1);
+    expect(coder_app?.instances[0].attributes.order).toBeNull();
+  });
+
   it("default to first ide", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -243,6 +243,7 @@ data "coder_parameter" "jetbrains_ide" {
 }
 
 data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
 
 resource "coder_app" "gateway" {
   agent_id     = var.agent_id
@@ -254,6 +255,8 @@ resource "coder_app" "gateway" {
   url = join("", [
     "jetbrains-gateway://connect#type=coder&workspace=",
     data.coder_workspace.me.name,
+    "&owner=",
+    data.coder_workspace_owner.me.name,
     "&agent=",
     var.agent_name,
     "&folder=",


### PR DESCRIPTION
Without this, it is not possible to reliably connect to another user's workspace (for admins, mainly) when duplicate workspace names are involved.