### PR TITLE
chore: explicitly setup terraform

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: coder/coder/.github/actions/setup-tf
+      - uses: coder/coder/.github/actions/setup-tf@main
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Needed to get tags
-      - uses: coder/coder/.github/actions/setup-tf
+      - uses: coder/coder/.github/actions/setup-tf@main
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: coder/coder/.github/actions/setup-tf
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -29,6 +30,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Needed to get tags
+      - uses: coder/coder/.github/actions/setup-tf
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest


### PR DESCRIPTION
CI started failing due to runner images missing the terraform.
I decided to use the same terraform version we use in coder/coder.