### PR TITLE
fix(kasmvnc): optimize KasmVNC deployment script

### DIFF
--- a/kasmvnc/README.md
+++ b/kasmvnc/README.md
@@ -14,7 +14,7 @@ Automatically install [KasmVNC](https://kasmweb.com/kasmvnc) in a workspace, and
 ```tf
 module "kasmvnc" {
   source              = "registry.coder.com/modules/kasmvnc/coder"
-  version             = "1.0.22"
+  version             = "1.0.23"
   agent_id            = coder_agent.example.id
   desktop_environment = "xfce"
 }

--- a/kasmvnc/main.tf
+++ b/kasmvnc/main.tf
@@ -42,7 +42,7 @@ resource "coder_script" "kasm_vnc" {
   script = templatefile("${path.module}/run.sh", {
     PORT : var.port,
     DESKTOP_ENVIRONMENT : var.desktop_environment,
-    VERSION : var.kasm_version
+    KASM_VERSION : var.kasm_version
   })
   run_on_start = true
 }

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -40,21 +40,6 @@ download_file() {
   }
 }
 
-# Add user to group using available commands
-add_user_to_group() {
-  local user="$1"
-  local group="$2"
-
-  if command -v usermod &> /dev/null; then
-    sudo usermod -aG "$group" "$user"
-  elif command -v adduser &> /dev/null; then
-    sudo adduser "$user" "$group"
-  else
-    echo "ERROR: At least one of 'adduser' or 'usermod' is required"
-    exit 1
-  fi
-}
-
 # Function to install kasmvncserver for debian-based distros
 install_deb() {
   local url=$1
@@ -72,8 +57,6 @@ install_deb() {
 
   DEBIAN_FRONTEND=noninteractive sudo apt-get -o DPkg::Lock::Timeout=300 install --yes -qq --no-install-recommends --no-install-suggests "$kasmdeb"
   rm "$kasmdeb"
-
-  add_user_to_group "$USER" ssl-cert
 }
 
 # Function to install kasmvncserver for rpm-based distros
@@ -117,7 +100,7 @@ install_alpine() {
   local kasmtgz="/tmp/kasmvncserver.tgz"
 
   download_file "$url" "$kasmtgz"
-  
+
   tar -xzf "$kasmtgz" -C /usr/local/bin/
   rm "$kasmtgz"
 }

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -181,10 +181,11 @@ echo -e "password\npassword\n" | vncpasswd -wo -u "$USER"
 # Start the server
 printf "🚀 Starting KasmVNC server...\n"
 vncserver -select-de "${DESKTOP_ENVIRONMENT}" -disableBasicAuth > /tmp/kasmvncserver.log 2>&1 &
+pid=$!
 
 # Wait for server to start
 sleep 5
-if ! pgrep -f vncserver > /dev/null; then
+if ps -p $pid | grep -q "^$pid"; then
   echo "ERROR: Failed to start KasmVNC server. Check logs at /tmp/kasmvncserver.log"
   grep -v '^[[:space:]]*$' /tmp/kasmvncserver.log
   exit 1

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -76,7 +76,7 @@ install_deb() {
 install_rpm() {
   local url=$1
   download_file "$url" /tmp/kasmvncserver.rpm
-  sudo rpm -i /tmp/kasmvncserver.rpm
+  sudo dnf localinstall /tmp/kasmvncserver.rpm
   rm /tmp/kasmvncserver.rpm
 }
 
@@ -116,7 +116,7 @@ echo "Detected Architecture: $arch"
 case "$arch" in
   x86_64)
     if [[ "$distro" =~ ^(ubuntu|debian|kali)$ ]]; then
-    	arch="amd64"
+      arch="amd64"
     fi
     ;;
   aarch64 | arm64)
@@ -161,7 +161,7 @@ else
   echo "vncserver already installed. Skipping installation."
 fi
 
-cat <<EOF > "$HOME/.vnc/kasmvnc.yaml"
+cat << EOF > "$HOME/.vnc/kasmvnc.yaml"
 network:
   protocol: http
   websocket_port: ${PORT}

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -186,7 +186,7 @@ else
   SUDO=
 
   echo "WARNING: Sudo access not available, using user config dir!"
-  
+
   if [[ -f "$kasm_config_file" ]]; then
     echo "WARNING: Custom user KasmVNC config exists, not overwriting!"
     echo "WARNIGN: Ensure that you manually configure the appropriate settings."

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -50,7 +50,7 @@ add_user_to_group() {
   elif command -v adduser &> /dev/null; then
     sudo adduser "$user" "$group"
   else
-    echo "ERROR: At least one of 'adduser'(Debian) 'usermod'(RHEL) is required"
+    echo "ERROR: At least one of 'adduser' or 'usermod' is required"
     exit 1
   fi
 }

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -99,6 +99,8 @@ arch="$(uname -m)"
 if [[ "$ID" == "ol" ]]; then
   distro="oracle"
   distro_version="$${distro_version%%.*}"
+elif [[ "$ID" == "fedora" ]]; then
+  distro_version="$(grep -oP '\(\K[\w ]+' /etc/fedora-release | tr '[:upper:]' '[:lower:]' | tr -d ' ')"
 fi
 
 echo "Detected Distribution: $distro"

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -161,7 +161,7 @@ else
   echo "vncserver already installed. Skipping installation."
 fi
 
-tee "$HOME/.vnc/kasmvnc.yaml" > /dev/null << EOF
+cat <<EOF > "$HOME/.vnc/kasmvnc.yaml"
 network:
   protocol: http
   websocket_port: ${PORT}

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -84,12 +84,6 @@ install_alpine() {
   rm /tmp/kasmvncserver.tgz
 }
 
-# Check for sudo (required)
-if ! command -v sudo &> /dev/null; then
-  echo "ERROR: Required command 'sudo' not found"
-  exit 1
-fi
-
 # Detect system information
 if [[ ! -f /etc/os-release ]]; then
   echo "ERROR: Cannot detect OS: /etc/os-release not found"
@@ -128,6 +122,12 @@ esac
 
 # Check if vncserver is installed, and install if not
 if ! check_installed; then
+  # Check for sudo (required)
+  if ! command -v sudo &> /dev/null; then
+    echo "ERROR: Required command 'sudo' not found"
+    exit 1
+  fi
+
   base_url="https://github.com/kasmtech/KasmVNC/releases/download/v${KASM_VERSION}"
 
   echo "Installing KASM version: ${KASM_VERSION}"

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -46,7 +46,7 @@ install_deb() {
   local kasmdeb="/tmp/kasmvncserver.deb"
 
   download_file "$url" "$kasmdeb"
-  
+
   CACHE_DIR="/var/lib/apt/lists/partial"
   # Check if the directory exists and was modified in the last 60 minutes
   if [[ ! -d "$CACHE_DIR" ]] || ! find "$CACHE_DIR" -mmin -60 -print -quit &> /dev/null; then
@@ -148,7 +148,7 @@ esac
 # Check if vncserver is installed, and install if not
 if ! check_installed; then
   # Check for NOPASSWD sudo (required)
-  if ! command -v sudo &>/dev/null || ! sudo -n true 2>/dev/null; then
+  if ! command -v sudo &> /dev/null || ! sudo -n true 2> /dev/null; then
     echo "ERROR: sudo NOPASSWD access required!"
     exit 1
   fi
@@ -178,7 +178,7 @@ else
   echo "vncserver already installed. Skipping installation."
 fi
 
-if command -v sudo &>/dev/null && sudo -n true 2>/dev/null; then
+if command -v sudo &> /dev/null && sudo -n true 2> /dev/null; then
   kasm_config_file="/etc/kasmvnc/kasmvnc.yaml"
   SUDO=sudo
 else
@@ -190,7 +190,7 @@ else
 fi
 
 echo "Writing KasmVNC config to $kasm_config_file"
-$SUDO tee "$kasm_config_file" > /dev/null <<EOF
+$SUDO tee "$kasm_config_file" > /dev/null << EOF
 network:
   protocol: http
   websocket_port: ${PORT}

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -188,4 +188,4 @@ if ! pgrep -f vncserver > /dev/null; then
   echo "ERROR: Failed to start KasmVNC server. Check logs at /tmp/kasmvncserver.log"
   exit 1
 fi
-printf "🚀 Starting KasmVNC server started successfully!\n"
+printf "🚀 KasmVNC server started successfully!\n"

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -58,7 +58,7 @@ install_deb() {
   # Define the directory to check
   CACHE_DIR="/var/lib/apt/lists/partial"
   # Check if the directory exists and was modified in the last 60 minutes
-  if [ ! -d "$CACHE_DIR" ] || ! find "$CACHE_DIR" -mmin -60 -print -quit &>/dev/null; then
+  if [ ! -d "$CACHE_DIR" ] || ! find "$CACHE_DIR" -mmin -60 -print -quit &> /dev/null; then
     echo "Stale Package Cache, updating..."
     # Update package cache with a 300-second timeout for dpkg lock
     sudo apt-get -o DPkg::Lock::Timeout=300 -qq update
@@ -117,7 +117,7 @@ case "$arch" in
   x86_64)
     [[ "$distro" =~ ^(ubuntu|debian|kali)$ ]] && arch="amd64" || arch="x86_64"
     ;;
-  aarch64|arm64)
+  aarch64 | arm64)
     [[ "$distro" =~ ^(ubuntu|debian|kali)$ ]] && arch="arm64" || arch="aarch64"
     ;;
   *)

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -170,7 +170,6 @@ echo -e "password\npassword\n" | vncpasswd -wo -u "$USER"
 
 # Start the server
 printf "🚀 Starting KasmVNC server...\n"
-# shellcheck disable=SC2024
 vncserver -select-de "${DESKTOP_ENVIRONMENT}" -disableBasicAuth > /tmp/kasmvncserver.log 2>&1 &
 
 # Wait for server to start

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -63,7 +63,7 @@ install_deb() {
   CACHE_DIR="/var/lib/apt/lists/partial"
   # Check if the directory exists and was modified in the last 60 minutes
   if [[ ! -d "$CACHE_DIR" ]] || ! find "$CACHE_DIR" -mmin -60 -print -quit &> /dev/null; then
-    echo "Stale Package Cache, updating..."
+    echo "Stale package cache, updating..."
     # Update package cache with a 300-second timeout for dpkg lock
     sudo apt-get -o DPkg::Lock::Timeout=300 -qq update
   fi

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -189,7 +189,7 @@ else
 
   if [[ -f "$kasm_config_file" ]]; then
     echo "WARNING: Custom user KasmVNC config exists, not overwriting!"
-    echo "WARNIGN: Ensure that you manually configure the appropriate settings."
+    echo "WARNING: Ensure that you manually configure the appropriate settings."
     kasm_config_file="/dev/stderr"
   else
     echo "WARNING: This may prevent custom user KasmVNC settings from applying!"

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -111,7 +111,9 @@ echo "Detected Architecture: $arch"
 # Map arch to package arch
 case "$arch" in
   x86_64)
-    [[ "$distro" =~ ^(ubuntu|debian|kali)$ ]] && arch="amd64" || arch="x86_64"
+    if [[ "$distro" =~ ^(ubuntu|debian|kali)$ ]]; then
+    	arch="amd64"
+    fi
     ;;
   aarch64 | arm64)
     [[ "$distro" =~ ^(ubuntu|debian|kali)$ ]] && arch="arm64" || arch="aarch64"

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -136,8 +136,13 @@ case "$arch" in
       arch="amd64"
     fi
     ;;
-  aarch64 | arm64)
-    [[ "$distro" =~ ^(ubuntu|debian|kali)$ ]] && arch="arm64" || arch="aarch64"
+  aarch64)
+    if [[ "$distro" =~ ^(ubuntu|debian|kali)$ ]]; then
+      arch="arm64"
+    fi
+    ;;
+  arm64)
+    :  # This is effectively a noop
     ;;
   *)
     echo "ERROR: Unsupported architecture: $arch"

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -184,9 +184,17 @@ if command -v sudo &> /dev/null && sudo -n true 2> /dev/null; then
 else
   kasm_config_file="$HOME/.vnc/kasmvnc.yaml"
   SUDO=
-  mkdir -p "$HOME/.vnc"
+
   echo "WARNING: Sudo access not available, using user config dir!"
-  echo "WARNING: This may prevent custom user KasmVNC settings from applying!"
+  
+  if [[ -f "$kasm_config_file" ]]; then
+    echo "WARNING: Custom user KasmVNC config exists, not overwriting!"
+    echo "WARNIGN: Ensure that you manually configure the appropriate settings."
+    kasm_config_file="/dev/stderr"
+  else
+    echo "WARNING: This may prevent custom user KasmVNC settings from applying!"
+    mkdir -p "$HOME/.vnc"
+  fi
 fi
 
 echo "Writing KasmVNC config to $kasm_config_file"

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-#!/bin/bash
+# Exit on error, undefined variables, and pipe failures
+set -euo pipefail
 
 # Function to check if vncserver is already installed
 check_installed() {
@@ -14,16 +15,38 @@ check_installed() {
 
 # Function to download a file using wget, curl, or busybox as a fallback
 download_file() {
-  local url=$1
-  local output=$2
-  if command -v wget &> /dev/null; then
-    wget $url -O $output
-  elif command -v curl &> /dev/null; then
-    curl -fsSL $url -o $output
+  local url="$1"
+  local output="$2"
+  local download_tool
+
+  if command -v curl &> /dev/null; then
+    download_tool="curl -fsSL"
+  elif command -v wget &> /dev/null; then
+    download_tool="wget -q -O-"
   elif command -v busybox &> /dev/null; then
-    busybox wget -O $output $url
+    download_tool="busybox wget -O-"
   else
-    echo "Neither wget, curl, nor busybox is installed. Please install one of them to proceed."
+    echo "ERROR: No download tool available (curl, wget, or busybox required)"
+    exit 1
+  fi
+
+  $download_tool "$url" > "$output" || {
+    echo "ERROR: Failed to download $url"
+    exit 1
+  }
+}
+
+# Add user to group using available commands
+add_user_to_group() {
+  local user="$1"
+  local group="$2"
+
+  if command -v usermod &> /dev/null; then
+    sudo usermod -aG "$group" "$user"
+  elif command -v adduser &> /dev/null; then
+    sudo adduser "$user" "$group"
+  else
+    echo "ERROR: At least one of 'adduser'(Debian) 'usermod'(RHEL) is required"
     exit 1
   fi
 }
@@ -31,38 +54,24 @@ download_file() {
 # Function to install kasmvncserver for debian-based distros
 install_deb() {
   local url=$1
-  download_file $url /tmp/kasmvncserver.deb
-  sudo apt-get update
-  DEBIAN_FRONTEND=noninteractive sudo apt-get install --yes -qq --no-install-recommends --no-install-suggests /tmp/kasmvncserver.deb
-  sudo adduser $USER ssl-cert
+  download_file "$url" /tmp/kasmvncserver.deb
+  # Define the directory to check
+  CACHE_DIR="/var/lib/apt/lists/partial"
+  # Check if the directory exists and was modified in the last 60 minutes
+  if [ ! -d "$CACHE_DIR" ] || ! find "$CACHE_DIR" -mmin -60 -print -quit &>/dev/null; then
+    echo "Stale Package Cache, updating..."
+    # Update package cache with a 300-second timeout for dpkg lock
+    sudo apt-get -o DPkg::Lock::Timeout=300 -qq update
+  fi
+  DEBIAN_FRONTEND=noninteractive sudo apt-get -o DPkg::Lock::Timeout=300 install --yes -qq --no-install-recommends --no-install-suggests /tmp/kasmvncserver.deb
+  add_user_to_group "$USER" ssl-cert
   rm /tmp/kasmvncserver.deb
-}
-
-# Function to install kasmvncserver for Oracle 8
-install_rpm_oracle8() {
-  local url=$1
-  download_file $url /tmp/kasmvncserver.rpm
-  sudo dnf config-manager --set-enabled ol8_codeready_builder
-  sudo dnf install oracle-epel-release-el8 -y
-  sudo dnf localinstall /tmp/kasmvncserver.rpm -y
-  sudo usermod -aG kasmvnc-cert $USER
-  rm /tmp/kasmvncserver.rpm
-}
-
-# Function to install kasmvncserver for CentOS 7
-install_rpm_centos7() {
-  local url=$1
-  download_file $url /tmp/kasmvncserver.rpm
-  sudo yum install epel-release -y
-  sudo yum install /tmp/kasmvncserver.rpm -y
-  sudo usermod -aG kasmvnc-cert $USER
-  rm /tmp/kasmvncserver.rpm
 }
 
 # Function to install kasmvncserver for rpm-based distros
 install_rpm() {
   local url=$1
-  download_file $url /tmp/kasmvncserver.rpm
+  download_file "$url" /tmp/kasmvncserver.rpm
   sudo rpm -i /tmp/kasmvncserver.rpm
   rm /tmp/kasmvncserver.rpm
 }
@@ -70,87 +79,73 @@ install_rpm() {
 # Function to install kasmvncserver for Alpine Linux
 install_alpine() {
   local url=$1
-  download_file $url /tmp/kasmvncserver.tgz
+  download_file "$url" /tmp/kasmvncserver.tgz
   tar -xzf /tmp/kasmvncserver.tgz -C /usr/local/bin/
   rm /tmp/kasmvncserver.tgz
 }
 
-# Detect system information
-distro=$(grep "^ID=" /etc/os-release | awk -F= '{print $2}')
-version=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
-arch=$(uname -m)
-
-echo "Detected Distribution: $distro"
-echo "Detected Version: $version"
-echo "Detected Architecture: $arch"
-
-# Map arch to package arch
-if [[ "$arch" == "x86_64" ]]; then
-  if [[ "$distro" == "ubuntu" || "$distro" == "debian" || "$distro" == "kali" ]]; then
-    arch="amd64"
-  else
-    arch="x86_64"
-  fi
-elif [[ "$arch" == "aarch64" || "$arch" == "arm64" ]]; then
-  if [[ "$distro" == "ubuntu" || "$distro" == "debian" || "$distro" == "kali" ]]; then
-    arch="arm64"
-  else
-    arch="aarch64"
-  fi
-else
-  echo "Unsupported architecture: $arch"
+# Check for sudo (required)
+if ! command -v sudo &> /dev/null; then
+  echo "ERROR: Required command 'sudo' not found"
   exit 1
 fi
 
+# Detect system information
+if [[ ! -f /etc/os-release ]]; then
+  echo "ERROR: Cannot detect OS: /etc/os-release not found"
+  exit 1
+fi
+
+# shellcheck disable=SC1091
+source /etc/os-release
+distro="$ID"
+distro_version="$VERSION_ID"
+codename="$VERSION_CODENAME"
+arch="$(uname -m)"
+if [[ "$ID" == "ol" ]]; then
+  distro="oracle"
+  distro_version="$${distro_version%%.*}"
+fi
+
+echo "Detected Distribution: $distro"
+echo "Detected Version: $distro_version"
+echo "Detected Codename: $codename"
+echo "Detected Architecture: $arch"
+
+# Map arch to package arch
+case "$arch" in
+  x86_64)
+    [[ "$distro" =~ ^(ubuntu|debian|kali)$ ]] && arch="amd64" || arch="x86_64"
+    ;;
+  aarch64|arm64)
+    [[ "$distro" =~ ^(ubuntu|debian|kali)$ ]] && arch="arm64" || arch="aarch64"
+    ;;
+  *)
+    echo "ERROR: Unsupported architecture: $arch"
+    exit 1
+    ;;
+esac
+
 # Check if vncserver is installed, and install if not
 if ! check_installed; then
-  echo "Installing KASM version: ${VERSION}"
+  base_url="https://github.com/kasmtech/KasmVNC/releases/download/v${KASM_VERSION}"
+
+  echo "Installing KASM version: ${KASM_VERSION}"
   case $distro in
     ubuntu | debian | kali)
-      case $version in
-        "20.04")
-          install_deb "https://github.com/kasmtech/KasmVNC/releases/download/v${VERSION}/kasmvncserver_focal_${VERSION}_$${arch}.deb"
-          ;;
-        "22.04")
-          install_deb "https://github.com/kasmtech/KasmVNC/releases/download/v${VERSION}/kasmvncserver_jammy_${VERSION}_$${arch}.deb"
-          ;;
-        "24.04")
-          install_deb "https://github.com/kasmtech/KasmVNC/releases/download/v${VERSION}/kasmvncserver_noble_${VERSION}_$${arch}.deb"
-          ;;
-        *)
-          echo "Unsupported Ubuntu/Debian/Kali version: $${version}"
-          exit 1
-          ;;
-      esac
+      bin_name="kasmvncserver_$${codename}_${KASM_VERSION}_$${arch}.deb"
+      install_deb "$base_url/$bin_name"
       ;;
-    oracle)
-      if [[ "$version" == "8" ]]; then
-        install_rpm_oracle8 "https://github.com/kasmtech/KasmVNC/releases/download/v${VERSION}/kasmvncserver_oracle_8_${VERSION}_$${arch}.rpm"
-      else
-        echo "Unsupported Oracle version: $${version}"
-        exit 1
-      fi
-      ;;
-    centos)
-      if [[ "$version" == "7" ]]; then
-        install_rpm_centos7 "https://github.com/kasmtech/KasmVNC/releases/download/v${VERSION}/kasmvncserver_centos_core_${VERSION}_$${arch}.rpm"
-      else
-        install_rpm "https://github.com/kasmtech/KasmVNC/releases/download/v${VERSION}/kasmvncserver_centos_core_${VERSION}_$${arch}.rpm"
-      fi
+    oracle | fedora | opensuse)
+      bin_name="kasmvncserver_$${distro}_$${distro_version}_${KASM_VERSION}_$${arch}.rpm"
+      install_rpm "$base_url/$bin_name"
       ;;
     alpine)
-      if [[ "$version" == "3.17" || "$version" == "3.18" || "$version" == "3.19" || "$version" == "3.20" ]]; then
-        install_alpine "https://github.com/kasmtech/KasmVNC/releases/download/v${VERSION}/kasmvnc.alpine_$${version}_$${arch}.tgz"
-      else
-        echo "Unsupported Alpine version: $${version}"
-        exit 1
-      fi
-      ;;
-    fedora | opensuse)
-      install_rpm "https://github.com/kasmtech/KasmVNC/releases/download/v${VERSION}/kasmvncserver_$${distro}_$${version}_${VERSION}_$${arch}.rpm"
+      bin_name="kasmvnc.alpine_$${distro_version//./}_$${arch}.tgz"
+      install_alpine "$base_url/$bin_name"
       ;;
     *)
-      echo "Unsupported distribution: $${distro}"
+      echo "Unsupported distribution: $distro"
       exit 1
       ;;
   esac
@@ -159,7 +154,7 @@ else
 fi
 
 # Coder port-forwarding from dashboard only supports HTTP
-sudo bash -c "cat > /etc/kasmvnc/kasmvnc.yaml <<EOF
+sudo tee /etc/kasmvnc/kasmvnc.yaml > /dev/null << EOF
 network:
   protocol: http
   websocket_port: ${PORT}
@@ -167,13 +162,21 @@ network:
     require_ssl: false
   udp:
     public_ip: 127.0.0.1
-EOF"
+EOF
 
 # This password is not used since we start the server without auth.
 # The server is protected via the Coder session token / tunnel
 # and does not listen publicly
-echo -e "password\npassword\n" | vncpasswd -wo -u $USER
+echo -e "password\npassword\n" | vncpasswd -wo -u "$USER"
 
 # Start the server
 printf "🚀 Starting KasmVNC server...\n"
-sudo -u $USER bash -c "vncserver -select-de ${DESKTOP_ENVIRONMENT} -disableBasicAuth" > /tmp/kasmvncserver.log 2>&1 &
+# shellcheck disable=SC2024
+sudo -u "$USER" bash -c "vncserver -select-de ${DESKTOP_ENVIRONMENT} -disableBasicAuth" > /tmp/kasmvncserver.log 2>&1 &
+
+# Wait for server to start
+sleep 5
+if ! pgrep -f vncserver > /dev/null; then
+  echo "ERROR: Failed to start KasmVNC server. Check logs at /tmp/kasmvncserver.log"
+  exit 1
+fi

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -185,9 +185,9 @@ pid=$!
 
 # Wait for server to start
 sleep 5
+grep -v '^[[:space:]]*$' /tmp/kasmvncserver.log | tail -n 10
 if ps -p $pid | grep -q "^$pid"; then
-  echo "ERROR: Failed to start KasmVNC server. Check logs at /tmp/kasmvncserver.log"
-  grep -v '^[[:space:]]*$' /tmp/kasmvncserver.log
+  echo "ERROR: Failed to start KasmVNC server. Check full logs at /tmp/kasmvncserver.log"
   exit 1
 fi
 printf "🚀 KasmVNC server started successfully!\n"

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -159,6 +159,8 @@ network:
   websocket_port: ${PORT}
   ssl:
     require_ssl: false
+    pem_certificate:
+    pem_key:
   udp:
     public_ip: 127.0.0.1
 EOF

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -172,7 +172,7 @@ echo -e "password\npassword\n" | vncpasswd -wo -u "$USER"
 # Start the server
 printf "🚀 Starting KasmVNC server...\n"
 # shellcheck disable=SC2024
-sudo -u "$USER" bash -c "vncserver -select-de ${DESKTOP_ENVIRONMENT} -disableBasicAuth" > /tmp/kasmvncserver.log 2>&1 &
+vncserver -select-de "${DESKTOP_ENVIRONMENT}" -disableBasicAuth > /tmp/kasmvncserver.log 2>&1 &
 
 # Wait for server to start
 sleep 5

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -62,7 +62,7 @@ install_deb() {
   # Define the directory to check
   CACHE_DIR="/var/lib/apt/lists/partial"
   # Check if the directory exists and was modified in the last 60 minutes
-  if [ ! -d "$CACHE_DIR" ] || ! find "$CACHE_DIR" -mmin -60 -print -quit &> /dev/null; then
+  if [[ ! -d "$CACHE_DIR" ]] || ! find "$CACHE_DIR" -mmin -60 -print -quit &> /dev/null; then
     echo "Stale Package Cache, updating..."
     # Update package cache with a 300-second timeout for dpkg lock
     sudo apt-get -o DPkg::Lock::Timeout=300 -qq update

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -142,7 +142,7 @@ case "$arch" in
     fi
     ;;
   arm64)
-    :  # This is effectively a noop
+    : # This is effectively a noop
     ;;
   *)
     echo "ERROR: Unsupported architecture: $arch"

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -157,6 +157,8 @@ tee "$HOME/.vnc/kasmvnc.yaml" > /dev/null << EOF
 network:
   protocol: http
   websocket_port: ${PORT}
+  ssl:
+    require_ssl: false
   udp:
     public_ip: 127.0.0.1
 EOF

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -179,3 +179,4 @@ if ! pgrep -f vncserver > /dev/null; then
   echo "ERROR: Failed to start KasmVNC server. Check logs at /tmp/kasmvncserver.log"
   exit 1
 fi
+printf "🚀 Starting KasmVNC server started successfully!\n"

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -153,13 +153,10 @@ else
   echo "vncserver already installed. Skipping installation."
 fi
 
-# Coder port-forwarding from dashboard only supports HTTP
-sudo tee /etc/kasmvnc/kasmvnc.yaml > /dev/null << EOF
+tee "$HOME/.vnc/kasmvnc.yaml" > /dev/null << EOF
 network:
   protocol: http
   websocket_port: ${PORT}
-  ssl:
-    require_ssl: false
   udp:
     public_ip: 127.0.0.1
 EOF

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -20,17 +20,21 @@ download_file() {
   local download_tool
 
   if command -v curl &> /dev/null; then
-    download_tool="curl -fsSL"
+    # shellcheck disable=SC2034
+    download_tool=(curl -fsSL)
   elif command -v wget &> /dev/null; then
-    download_tool="wget -q -O-"
+    # shellcheck disable=SC2034
+    download_tool=(wget -q -O-)
   elif command -v busybox &> /dev/null; then
-    download_tool="busybox wget -O-"
+    # shellcheck disable=SC2034
+    download_tool=(busybox wget -O-)
   else
     echo "ERROR: No download tool available (curl, wget, or busybox required)"
     exit 1
   fi
 
-  $download_tool "$url" > "$output" || {
+  # shellcheck disable=SC2288
+  "$${download_tool[@]}" "$url" > "$output" || {
     echo "ERROR: Failed to download $url"
     exit 1
   }

--- a/kasmvnc/run.sh
+++ b/kasmvnc/run.sh
@@ -186,6 +186,7 @@ vncserver -select-de "${DESKTOP_ENVIRONMENT}" -disableBasicAuth > /tmp/kasmvncse
 sleep 5
 if ! pgrep -f vncserver > /dev/null; then
   echo "ERROR: Failed to start KasmVNC server. Check logs at /tmp/kasmvncserver.log"
+  grep -v '^[[:space:]]*$' /tmp/kasmvncserver.log
   exit 1
 fi
 printf "🚀 KasmVNC server started successfully!\n"


### PR DESCRIPTION
I took the opportunity to majorly refactor the run.sh script.

Basically a rewrite from the ground up, and I found a few things that I don't think were tested for non-Ubuntu distros.

I updated the Kasm Version reference to avoid confusion in the script.
https://github.com/coder/modules/blob/a8cc861e831d796914f965ec5c6c5b1b59aa9118/kasmvnc/main.tf#L42-L46

Removed the extra shebang and added an early exit signal in case of failure.
https://github.com/coder/modules/blob/a8cc861e831d796914f965ec5c6c5b1b59aa9118/kasmvnc/run.sh#L1-L4

Optimize the download function to set the command and then one block of logic to perform the download and handle a failure.
https://github.com/coder/modules/blob/a8cc861e831d796914f965ec5c6c5b1b59aa9118/kasmvnc/run.sh#L16-L37

Created a cross platform function to add a user to a group based on which command is available.
https://github.com/coder/modules/blob/a8cc861e831d796914f965ec5c6c5b1b59aa9118/kasmvnc/run.sh#L39-L52

Refactored the `install_deb` function to dynamically update the (stale) package cache and wait for a lock.
https://github.com/coder/modules/blob/a8cc861e831d796914f965ec5c6c5b1b59aa9118/kasmvnc/run.sh#L54-L69

Check and fail early if sudo or /etc/os-release are not available.

Source `/etc/os-release` since it is formatted as a `.env` file.
Also, adjust the distro and version for Oracle.
Note we are using `distro_version` to make it more readable vs just version.
https://github.com/coder/modules/blob/a8cc861e831d796914f965ec5c6c5b1b59aa9118/kasmvnc/run.sh#L100-L108

Cleaned up the ARCH mappings to make it more readable.
https://github.com/coder/modules/blob/a8cc861e831d796914f965ec5c6c5b1b59aa9118/kasmvnc/run.sh#L115-L127

For installation, set a base URL that is the same for all distros.
Cleaned up the cases and merged ones that could be merged.
Reduced checking for specific distro versions, we want this to be compatible with future versions without modifying the script each time. If KASM doesn't support the version, then it will fail during the attempt to download.
https://github.com/coder/modules/blob/a8cc861e831d796914f965ec5c6c5b1b59aa9118/kasmvnc/run.sh#L129-L154

Finally, added a check to verify that the VNC server was actually running.
https://github.com/coder/modules/blob/a8cc861e831d796914f965ec5c6c5b1b59aa9118/kasmvnc/run.sh#L177-L182


Also closes #327
