### PR TITLE
feat(jetbrains-gateway): add releases_base_link/download_base_link variables

### DIFF
--- a/jetbrains-gateway/README.md
+++ b/jetbrains-gateway/README.md
@@ -72,6 +72,22 @@ module "jetbrains_gateway" {
 }
 ```
 
+### Custom base link
+
+```tf
+module "jetbrains_gateway" {
+  source                = "registry.coder.com/modules/jetbrains-gateway/coder"
+  version               = "1.0.21"
+  agent_id              = coder_agent.example.id
+  agent_name            = "example"
+  folder                = "/home/coder/example"
+  jetbrains_ides        = ["GO", "WS"]
+  releases_base_link    = "https://releases.internal.site/"
+  download_base_link    = "https://download.internal.site/"
+  default               = "GO"
+}
+```
+
 ## Supported IDEs
 
 This module and JetBrains Gateway support the following JetBrains IDEs:

--- a/jetbrains-gateway/README.md
+++ b/jetbrains-gateway/README.md
@@ -76,15 +76,15 @@ module "jetbrains_gateway" {
 
 ```tf
 module "jetbrains_gateway" {
-  source                = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version               = "1.0.21"
-  agent_id              = coder_agent.example.id
-  agent_name            = "example"
-  folder                = "/home/coder/example"
-  jetbrains_ides        = ["GO", "WS"]
-  releases_base_link    = "https://releases.internal.site/"
-  download_base_link    = "https://download.internal.site/"
-  default               = "GO"
+  source             = "registry.coder.com/modules/jetbrains-gateway/coder"
+  version            = "1.0.21"
+  agent_id           = coder_agent.example.id
+  agent_name         = "example"
+  folder             = "/home/coder/example"
+  jetbrains_ides     = ["GO", "WS"]
+  releases_base_link = "https://releases.internal.site/"
+  download_base_link = "https://download.internal.site/"
+  default            = "GO"
 }
 ```
 

--- a/jetbrains-gateway/README.md
+++ b/jetbrains-gateway/README.md
@@ -14,7 +14,7 @@ This module adds a JetBrains Gateway Button to open any workspace with a single 
 ```tf
 module "jetbrains_gateway" {
   source         = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version        = "1.0.21"
+  version        = "1.0.23"
   agent_id       = coder_agent.example.id
   agent_name     = "example"
   folder         = "/home/coder/example"
@@ -32,7 +32,7 @@ module "jetbrains_gateway" {
 ```tf
 module "jetbrains_gateway" {
   source         = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version        = "1.0.21"
+  version        = "1.0.23"
   agent_id       = coder_agent.example.id
   agent_name     = "example"
   folder         = "/home/coder/example"
@@ -46,7 +46,7 @@ module "jetbrains_gateway" {
 ```tf
 module "jetbrains_gateway" {
   source         = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version        = "1.0.21"
+  version        = "1.0.23"
   agent_id       = coder_agent.example.id
   agent_name     = "example"
   folder         = "/home/coder/example"
@@ -61,7 +61,7 @@ module "jetbrains_gateway" {
 ```tf
 module "jetbrains_gateway" {
   source         = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version        = "1.0.21"
+  version        = "1.0.23"
   agent_id       = coder_agent.example.id
   agent_name     = "example"
   folder         = "/home/coder/example"
@@ -79,7 +79,7 @@ Due to the highest priority of the `ide_download_link` parameter in the `(jetbra
 ```tf
 module "jetbrains_gateway" {
   source             = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version            = "1.0.21"
+  version            = "1.0.23"
   agent_id           = coder_agent.example.id
   agent_name         = "example"
   folder             = "/home/coder/example"

--- a/jetbrains-gateway/README.md
+++ b/jetbrains-gateway/README.md
@@ -74,6 +74,8 @@ module "jetbrains_gateway" {
 
 ### Custom base link
 
+Due to the highest priority of the `ide_download_link` parameter in the `(jetbrains-gateway://...` within IDEA, the pre-configured download address will be overridden when using [IDEA's offline mode](https://www.jetbrains.com/help/idea/fully-offline-mode.html). Therefore, it is necessary to configure the `download_base_link` parameter for the `jetbrains_gateway` module to change the value of `ide_download_link`.
+
 ```tf
 module "jetbrains_gateway" {
   source             = "registry.coder.com/modules/jetbrains-gateway/coder"

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -151,7 +151,7 @@ variable "releases_base_link" {
   description = ""
   default     = "https://data.services.jetbrains.com"
   validation {
-    condition     = can(regex("^(https?:\/\/)?[0-9a-zA-Z]+\.[-_0-9a-zA-Z]+\.[0-9a-zA-Z]+$", var.releases_base_link))
+    condition     = can(regex("^https?://.+$", var.releases_base_link))
     error_message = "The releases_base_link must be a valid HTTP/S address."
   }
 }
@@ -161,7 +161,7 @@ variable "download_base_link" {
   description = ""
   default     = "https://download.jetbrains.com"
   validation {
-    condition     = can(regex("^(https?:\/\/)?[0-9a-zA-Z]+\.[-_0-9a-zA-Z]+\.[0-9a-zA-Z]+$", var.download_base_link))
+    condition     = can(regex("^https?://.+$", var.download_base_link))
     error_message = "The download_base_link must be a valid HTTP/S address."
   }
 }

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -146,9 +146,29 @@ variable "jetbrains_ides" {
   }
 }
 
+variable "releases_base_link" {
+  type        = string
+  description = ""
+  default     = "https://data.services.jetbrains.com"
+  validation {
+    condition     = can(regex("^(https?:\/\/)?[0-9a-zA-Z]+\.[-_0-9a-zA-Z]+\.[0-9a-zA-Z]+$", var.releases_base_link))
+    error_message = "The releases_base_link must be a valid HTTP/S address."
+  }
+}
+
+variable "download_base_link" {
+  type        = string
+  description = ""
+  default     = "https://download.jetbrains.com"
+  validation {
+    condition     = can(regex("^(https?:\/\/)?[0-9a-zA-Z]+\.[-_0-9a-zA-Z]+\.[0-9a-zA-Z]+$", var.download_base_link))
+    error_message = "The download_base_link must be a valid HTTP/S address."
+  }
+}
+
 data "http" "jetbrains_ide_versions" {
   for_each = var.latest ? toset(var.jetbrains_ides) : toset([])
-  url      = "https://data.services.jetbrains.com/products/releases?code=${each.key}&latest=true&type=${var.channel}"
+  url      = "${var.releases_base_link}/products/releases?code=${each.key}&latest=true&type=${var.channel}"
 }
 
 locals {
@@ -158,7 +178,7 @@ locals {
       name          = "GoLand",
       identifier    = "GO",
       build_number  = var.jetbrains_ide_versions["GO"].build_number,
-      download_link = "https://download.jetbrains.com/go/goland-${var.jetbrains_ide_versions["GO"].version}.tar.gz"
+      download_link = "${var.download_base_link}/go/goland-${var.jetbrains_ide_versions["GO"].version}.tar.gz"
       version       = var.jetbrains_ide_versions["GO"].version
     },
     "WS" = {
@@ -166,7 +186,7 @@ locals {
       name          = "WebStorm",
       identifier    = "WS",
       build_number  = var.jetbrains_ide_versions["WS"].build_number,
-      download_link = "https://download.jetbrains.com/webstorm/WebStorm-${var.jetbrains_ide_versions["WS"].version}.tar.gz"
+      download_link = "${var.download_base_link}/webstorm/WebStorm-${var.jetbrains_ide_versions["WS"].version}.tar.gz"
       version       = var.jetbrains_ide_versions["WS"].version
     },
     "IU" = {
@@ -174,7 +194,7 @@ locals {
       name          = "IntelliJ IDEA Ultimate",
       identifier    = "IU",
       build_number  = var.jetbrains_ide_versions["IU"].build_number,
-      download_link = "https://download.jetbrains.com/idea/ideaIU-${var.jetbrains_ide_versions["IU"].version}.tar.gz"
+      download_link = "${var.download_base_link}/idea/ideaIU-${var.jetbrains_ide_versions["IU"].version}.tar.gz"
       version       = var.jetbrains_ide_versions["IU"].version
     },
     "PY" = {
@@ -182,7 +202,7 @@ locals {
       name          = "PyCharm Professional",
       identifier    = "PY",
       build_number  = var.jetbrains_ide_versions["PY"].build_number,
-      download_link = "https://download.jetbrains.com/python/pycharm-professional-${var.jetbrains_ide_versions["PY"].version}.tar.gz"
+      download_link = "${var.download_base_link}/python/pycharm-professional-${var.jetbrains_ide_versions["PY"].version}.tar.gz"
       version       = var.jetbrains_ide_versions["PY"].version
     },
     "CL" = {
@@ -190,7 +210,7 @@ locals {
       name          = "CLion",
       identifier    = "CL",
       build_number  = var.jetbrains_ide_versions["CL"].build_number,
-      download_link = "https://download.jetbrains.com/cpp/CLion-${var.jetbrains_ide_versions["CL"].version}.tar.gz"
+      download_link = "${var.download_base_link}/cpp/CLion-${var.jetbrains_ide_versions["CL"].version}.tar.gz"
       version       = var.jetbrains_ide_versions["CL"].version
     },
     "PS" = {
@@ -198,7 +218,7 @@ locals {
       name          = "PhpStorm",
       identifier    = "PS",
       build_number  = var.jetbrains_ide_versions["PS"].build_number,
-      download_link = "https://download.jetbrains.com/webide/PhpStorm-${var.jetbrains_ide_versions["PS"].version}.tar.gz"
+      download_link = "${var.download_base_link}/webide/PhpStorm-${var.jetbrains_ide_versions["PS"].version}.tar.gz"
       version       = var.jetbrains_ide_versions["PS"].version
     },
     "RM" = {
@@ -206,7 +226,7 @@ locals {
       name          = "RubyMine",
       identifier    = "RM",
       build_number  = var.jetbrains_ide_versions["RM"].build_number,
-      download_link = "https://download.jetbrains.com/ruby/RubyMine-${var.jetbrains_ide_versions["RM"].version}.tar.gz"
+      download_link = "${var.download_base_link}/ruby/RubyMine-${var.jetbrains_ide_versions["RM"].version}.tar.gz"
       version       = var.jetbrains_ide_versions["RM"].version
     }
     "RD" = {
@@ -214,7 +234,7 @@ locals {
       name          = "Rider",
       identifier    = "RD",
       build_number  = var.jetbrains_ide_versions["RD"].build_number,
-      download_link = "https://download.jetbrains.com/rider/JetBrains.Rider-${var.jetbrains_ide_versions["RD"].version}.tar.gz"
+      download_link = "${var.download_base_link}/rider/JetBrains.Rider-${var.jetbrains_ide_versions["RD"].version}.tar.gz"
       version       = var.jetbrains_ide_versions["RD"].version
     }
   }


### PR DESCRIPTION
* Enhance the jetbrains-gateway module to support custom download link.

In [offline mode](https://www.jetbrains.com/help/idea/fully-offline-mode.html), the currently configured offline download address will be overridden by the parameters of jetbrains-gateway(jetbrains-gateway://connect#......&ide_download_link=https://download.jetbrains.com/idea/ideaIU-XXX.tar.gz).