### PR TITLE
feat(jetbrains-gateway): bump to 2024.3

### DIFF
--- a/jetbrains-gateway/README.md
+++ b/jetbrains-gateway/README.md
@@ -14,7 +14,7 @@ This module adds a JetBrains Gateway Button to open any workspace with a single 
 ```tf
 module "jetbrains_gateway" {
   source         = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version        = "1.0.23"
+  version        = "1.0.25"
   agent_id       = coder_agent.example.id
   agent_name     = "example"
   folder         = "/home/coder/example"
@@ -32,7 +32,7 @@ module "jetbrains_gateway" {
 ```tf
 module "jetbrains_gateway" {
   source         = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version        = "1.0.23"
+  version        = "1.0.25"
   agent_id       = coder_agent.example.id
   agent_name     = "example"
   folder         = "/home/coder/example"
@@ -46,7 +46,7 @@ module "jetbrains_gateway" {
 ```tf
 module "jetbrains_gateway" {
   source         = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version        = "1.0.23"
+  version        = "1.0.25"
   agent_id       = coder_agent.example.id
   agent_name     = "example"
   folder         = "/home/coder/example"
@@ -61,7 +61,7 @@ module "jetbrains_gateway" {
 ```tf
 module "jetbrains_gateway" {
   source         = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version        = "1.0.23"
+  version        = "1.0.25"
   agent_id       = coder_agent.example.id
   agent_name     = "example"
   folder         = "/home/coder/example"
@@ -79,7 +79,7 @@ Due to the highest priority of the `ide_download_link` parameter in the `(jetbra
 ```tf
 module "jetbrains_gateway" {
   source             = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version            = "1.0.23"
+  version            = "1.0.25"
   agent_id           = coder_agent.example.id
   agent_name         = "example"
   folder             = "/home/coder/example"

--- a/jetbrains-gateway/README.md
+++ b/jetbrains-gateway/README.md
@@ -41,7 +41,7 @@ module "jetbrains_gateway" {
 }
 ```
 
-### Use the fixed set by `jetbrains_ide_versions`
+### Use fixed versions set by `jetbrains_ide_versions`
 
 ```tf
 module "jetbrains_gateway" {
@@ -53,6 +53,40 @@ module "jetbrains_gateway" {
   jetbrains_ides = ["GO", "WS"]
   default        = "GO"
   latest         = false
+  jetbrains_ide_versions = {
+    "IU" = {
+      build_number = "243.21565.193"
+      version      = "2024.3"
+    }
+    "PS" = {
+      build_number = "243.21565.202"
+      version      = "2024.3"
+    }
+    "WS" = {
+      build_number = "243.21565.180"
+      version      = "2024.3"
+    }
+    "PY" = {
+      build_number = "243.21565.199"
+      version      = "2024.3"
+    }
+    "CL" = {
+      build_number = "243.21565.238"
+      version      = "2024.1"
+    }
+    "GO" = {
+      build_number = "243.21565.208"
+      version      = "2024.3"
+    }
+    "RM" = {
+      build_number = "243.21565.197"
+      version      = "2024.3"
+    }
+    "RD" = {
+      build_number = "243.21565.191"
+      version      = "2024.3"
+    }
+  }
 }
 ```
 

--- a/jetbrains-gateway/README.md
+++ b/jetbrains-gateway/README.md
@@ -50,40 +50,16 @@ module "jetbrains_gateway" {
   agent_id       = coder_agent.example.id
   agent_name     = "example"
   folder         = "/home/coder/example"
-  jetbrains_ides = ["GO", "WS"]
-  default        = "GO"
+  jetbrains_ides = ["IU", "PY"]
+  default        = "IU"
   latest         = false
   jetbrains_ide_versions = {
     "IU" = {
       build_number = "243.21565.193"
       version      = "2024.3"
     }
-    "PS" = {
-      build_number = "243.21565.202"
-      version      = "2024.3"
-    }
-    "WS" = {
-      build_number = "243.21565.180"
-      version      = "2024.3"
-    }
     "PY" = {
       build_number = "243.21565.199"
-      version      = "2024.3"
-    }
-    "CL" = {
-      build_number = "243.21565.238"
-      version      = "2024.1"
-    }
-    "GO" = {
-      build_number = "243.21565.208"
-      version      = "2024.3"
-    }
-    "RM" = {
-      build_number = "243.21565.197"
-      version      = "2024.3"
-    }
-    "RD" = {
-      build_number = "243.21565.191"
       version      = "2024.3"
     }
   }

--- a/jetbrains-gateway/README.md
+++ b/jetbrains-gateway/README.md
@@ -41,7 +41,7 @@ module "jetbrains_gateway" {
 }
 ```
 
-### Use the latest release version
+### Use the fixed set by `jetbrains_ide_versions`
 
 ```tf
 module "jetbrains_gateway" {
@@ -52,7 +52,7 @@ module "jetbrains_gateway" {
   folder         = "/home/coder/example"
   jetbrains_ides = ["GO", "WS"]
   default        = "GO"
-  latest         = true
+  latest         = false
 }
 ```
 

--- a/jetbrains-gateway/README.md
+++ b/jetbrains-gateway/README.md
@@ -41,6 +41,21 @@ module "jetbrains_gateway" {
 }
 ```
 
+### Use the latest version of each IDE
+
+```tf
+module "jetbrains_gateway" {
+  source         = "registry.coder.com/modules/jetbrains-gateway/coder"
+  version        = "1.0.25"
+  agent_id       = coder_agent.example.id
+  agent_name     = "example"
+  folder         = "/home/coder/example"
+  jetbrains_ides = ["IU", "PY"]
+  default        = "IU"
+  latest         = true
+}
+```
+
 ### Use fixed versions set by `jetbrains_ide_versions`
 
 ```tf

--- a/jetbrains-gateway/main.test.ts
+++ b/jetbrains-gateway/main.test.ts
@@ -22,7 +22,7 @@ describe("jetbrains-gateway", async () => {
       folder: "/home/coder",
     });
     expect(state.outputs.url.value).toBe(
-      "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&agent=foo&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=241.14494.240&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.1.tar.gz",
+      "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&agent=foo&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=243.21565.193&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz",
     );
 
     const coder_app = state.resources.find(

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -59,7 +59,7 @@ variable "coder_parameter_order" {
 variable "latest" {
   type        = bool
   description = "Whether to fetch the latest version of the IDE."
-  default     = true
+  default     = false
 }
 
 variable "channel" {

--- a/jetbrains-gateway/main.tf
+++ b/jetbrains-gateway/main.tf
@@ -59,7 +59,7 @@ variable "coder_parameter_order" {
 variable "latest" {
   type        = bool
   description = "Whether to fetch the latest version of the IDE."
-  default     = false
+  default     = true
 }
 
 variable "channel" {
@@ -80,36 +80,36 @@ variable "jetbrains_ide_versions" {
   description = "The set of versions for each jetbrains IDE"
   default = {
     "IU" = {
-      build_number = "241.14494.240"
-      version      = "2024.1"
+      build_number = "243.21565.193"
+      version      = "2024.3"
     }
     "PS" = {
-      build_number = "241.14494.237"
-      version      = "2024.1"
+      build_number = "243.21565.202"
+      version      = "2024.3"
     }
     "WS" = {
-      build_number = "241.14494.235"
-      version      = "2024.1"
+      build_number = "243.21565.180"
+      version      = "2024.3"
     }
     "PY" = {
-      build_number = "241.14494.241"
-      version      = "2024.1"
+      build_number = "243.21565.199"
+      version      = "2024.3"
     }
     "CL" = {
-      build_number = "241.14494.288"
+      build_number = "243.21565.238"
       version      = "2024.1"
     }
     "GO" = {
-      build_number = "241.14494.238"
-      version      = "2024.1"
+      build_number = "243.21565.208"
+      version      = "2024.3"
     }
     "RM" = {
-      build_number = "241.14494.234"
-      version      = "2024.1"
+      build_number = "243.21565.197"
+      version      = "2024.3"
     }
     "RD" = {
-      build_number = "241.14494.307"
-      version      = "2024.1"
+      build_number = "243.21565.191"
+      version      = "2024.3"
     }
   }
   validation {


### PR DESCRIPTION
1. Bumps default IDE versions to 2024.3
2. Set the default value of `latest=true` to always fetch the latest versions.

Extracted from #339 as that introduces a breaking change.