### PR TITLE
fix(update-versions.sh): handle markdown/tf block nesting when updating version

### DIFF
--- a/update-version.sh
+++ b/update-version.sh
@@ -21,14 +21,39 @@ for dir in "${changed_dirs[@]}"; do
   if [[ -f "$dir/README.md" ]]; then
     file="$dir/README.md"
     tmpfile=$(mktemp /tmp/tempfile.XXXXXX)
-    awk -v tag="$LATEST_TAG" '{
-      if ($1 == "version" && $2 == "=") {
-        sub(/"[^"]*"/, "\"" tag "\"")
-        print
-      } else {
+    awk -v tag="$LATEST_TAG" '
+      BEGIN { in_code_block = 0; in_nested_block = 0 }
+      {
+        # Detect the start and end of Markdown code blocks.
+        if ($0 ~ /^```/) {
+          in_code_block = !in_code_block
+          # Reset nested block tracking when exiting a code block.
+          if (!in_code_block) {
+            in_nested_block = 0
+          }
+        }
+
+        # Handle nested blocks within a code block.
+        if (in_code_block) {
+          # Detect the start of a nested block (skipping "module" blocks).
+          if ($0 ~ /{/ && !($1 == "module" || $1 ~ /^[a-zA-Z0-9_]+$/)) {
+            in_nested_block++
+          }
+
+          # Detect the end of a nested block.
+          if ($0 ~ /}/ && in_nested_block > 0) {
+            in_nested_block--
+          }
+
+          # Update "version" only if not in a nested block.
+          if (!in_nested_block && $1 == "version" && $2 == "=") {
+            sub(/"[^"]*"/, "\"" tag "\"")
+          }
+        }
+
         print
       }
-    }' "$file" > "$tmpfile" && mv "$tmpfile" "$file"
+    ' "$file" > "$tmpfile" && mv "$tmpfile" "$file"
 
     # Check if the README.md file has changed
     if ! git diff --quiet -- "$dir/README.md"; then


### PR DESCRIPTION
The script was too greedy and updating unrelated fields in #355.

This change makes the script much more strict, only updating version on the top-level _iff_ within a markdown code-block.
