### PR TITLE
chore(git-commit-signing): add version warning in README

### DIFF
--- a/git-commit-signing/README.md
+++ b/git-commit-signing/README.md
@@ -10,7 +10,7 @@ tags: [helper, git]
 # git-commit-signing
 
 > [!IMPORTANT]  
-> This module will only work with Git version >=2.4, prior versions [do not support signing commits via SSH keys](https://lore.kernel.org/git/xmqq8rxpgwki.fsf@gitster.g/).
+> This module will only work with Git versions >=2.34, prior versions [do not support signing commits via SSH keys](https://lore.kernel.org/git/xmqq8rxpgwki.fsf@gitster.g/).
 
 This module downloads your SSH key from Coder and uses it to sign commits with Git.
 It requires `curl` and `jq` to be installed inside your workspace.

--- a/git-commit-signing/README.md
+++ b/git-commit-signing/README.md
@@ -9,6 +9,9 @@ tags: [helper, git]
 
 # git-commit-signing
 
+> [!IMPORTANT]  
+> This module will only work with Git version >=2.4, prior versions [do not support signing commits via SSH keys](https://lore.kernel.org/git/xmqq8rxpgwki.fsf@gitster.g/).
+
 This module downloads your SSH key from Coder and uses it to sign commits with Git.
 It requires `curl` and `jq` to be installed inside your workspace.
 


### PR DESCRIPTION
Git versions prior to 2.34 do not support commit signing via an SSH key.

I was willing to add a check in the script, but Git does not return the version as-is (sometimes also returns the commit hash) and we would need to compare versions, I think this would add unnecessary dependencies, what do you think @matifali?
```
coder@catfood> git -v
git version 2.47.0
```