### PR TITLE
chore: set git clone & dotfiles as optional

### DIFF
--- a/dotfiles/run.sh
+++ b/dotfiles/run.sh
@@ -18,6 +18,6 @@ if [ -n "$${DOTFILES_URI// }" ]; then
 
     CODER_BIN=$(which coder)
     DOTFILES_USER_HOME=$(eval echo ~"$DOTFILES_USER")
-    sudo -u "$DOTFILES_USER" sh -c "'$CODER_BIN' dotfiles '$DOTFILES_URI' -y 2>&1 | tee '$DOTFILES_USER_HOME'/.dotfiles.log"
+    sudo -u "$DOTFILES_USER" sh -c "'$CODER_BIN' dotfiles '$DOTFILES_URI' -y 2>&1 | tee '$DOTFILES_USER_HOME'/.dotfiles.log || true"
   fi
 fi

--- a/git-clone/run.sh
+++ b/git-clone/run.sh
@@ -9,7 +9,7 @@ CLONE_PATH="$${CLONE_PATH/#\~/$${HOME}}"
 # Check if the variable is empty...
 if [ -z "$REPO_URL" ]; then
   echo "No repository specified!"
-  exit 1
+  exit 0
 fi
 
 # Check if the variable is empty...


### PR DESCRIPTION
customers are making good use of our dotfiles & git clone modules. however, there are scenarios where users may not want to set a repo URL or dotfiles URL, despite the module being present in the template.

the changes in this PR prevent the modules from failing if such fields are unset.