### PR TITLE
fix(dotfiles): handle failures in dotfiles installation

### DIFF
--- a/dotfiles/README.md
+++ b/dotfiles/README.md
@@ -19,7 +19,7 @@ Under the hood, this module uses the [coder dotfiles](https://coder.com/docs/v2/
 module "dotfiles" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/modules/dotfiles/coder"
-  version  = "1.0.18"
+  version  = "1.0.28"
   agent_id = coder_agent.example.id
 }
 ```
@@ -32,7 +32,7 @@ module "dotfiles" {
 module "dotfiles" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/modules/dotfiles/coder"
-  version  = "1.0.18"
+  version  = "1.0.28"
   agent_id = coder_agent.example.id
 }
 ```
@@ -43,7 +43,7 @@ module "dotfiles" {
 module "dotfiles" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/modules/dotfiles/coder"
-  version  = "1.0.18"
+  version  = "1.0.28"
   agent_id = coder_agent.example.id
   user     = "root"
 }
@@ -55,14 +55,14 @@ module "dotfiles" {
 module "dotfiles" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/modules/dotfiles/coder"
-  version  = "1.0.18"
+  version  = "1.0.28"
   agent_id = coder_agent.example.id
 }
 
 module "dotfiles-root" {
   count        = data.coder_workspace.me.start_count
   source       = "registry.coder.com/modules/dotfiles/coder"
-  version      = "1.0.18"
+  version      = "1.0.28"
   agent_id     = coder_agent.example.id
   user         = "root"
   dotfiles_uri = module.dotfiles.dotfiles_uri
@@ -77,7 +77,7 @@ You can set a default dotfiles repository for all users by setting the `default_
 module "dotfiles" {
   count                = data.coder_workspace.me.start_count
   source               = "registry.coder.com/modules/dotfiles/coder"
-  version              = "1.0.18"
+  version              = "1.0.28"
   agent_id             = coder_agent.example.id
   default_dotfiles_uri = "https://github.com/coder/dotfiles"
 }

--- a/dotfiles/README.md
+++ b/dotfiles/README.md
@@ -19,7 +19,7 @@ Under the hood, this module uses the [coder dotfiles](https://coder.com/docs/v2/
 module "dotfiles" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/modules/dotfiles/coder"
-  version  = "1.0.28"
+  version  = "1.0.29"
   agent_id = coder_agent.example.id
 }
 ```
@@ -32,7 +32,7 @@ module "dotfiles" {
 module "dotfiles" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/modules/dotfiles/coder"
-  version  = "1.0.28"
+  version  = "1.0.29"
   agent_id = coder_agent.example.id
 }
 ```
@@ -43,7 +43,7 @@ module "dotfiles" {
 module "dotfiles" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/modules/dotfiles/coder"
-  version  = "1.0.28"
+  version  = "1.0.29"
   agent_id = coder_agent.example.id
   user     = "root"
 }
@@ -55,14 +55,14 @@ module "dotfiles" {
 module "dotfiles" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/modules/dotfiles/coder"
-  version  = "1.0.28"
+  version  = "1.0.29"
   agent_id = coder_agent.example.id
 }
 
 module "dotfiles-root" {
   count        = data.coder_workspace.me.start_count
   source       = "registry.coder.com/modules/dotfiles/coder"
-  version      = "1.0.28"
+  version      = "1.0.29"
   agent_id     = coder_agent.example.id
   user         = "root"
   dotfiles_uri = module.dotfiles.dotfiles_uri
@@ -77,7 +77,7 @@ You can set a default dotfiles repository for all users by setting the `default_
 module "dotfiles" {
   count                = data.coder_workspace.me.start_count
   source               = "registry.coder.com/modules/dotfiles/coder"
-  version              = "1.0.28"
+  version              = "1.0.29"
   agent_id             = coder_agent.example.id
   default_dotfiles_uri = "https://github.com/coder/dotfiles"
 }

--- a/dotfiles/run.sh
+++ b/dotfiles/run.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -euo pipefail
+
 DOTFILES_URI="${DOTFILES_URI}"
 DOTFILES_USER="${DOTFILES_USER}"
 
@@ -19,9 +22,5 @@ if [ -n "$${DOTFILES_URI// }" ]; then
     CODER_BIN=$(which coder)
     DOTFILES_USER_HOME=$(eval echo ~"$DOTFILES_USER")
     sudo -u "$DOTFILES_USER" sh -c "'$CODER_BIN' dotfiles '$DOTFILES_URI' -y 2>&1 | tee '$DOTFILES_USER_HOME'/.dotfiles.log"
-  fi
-  if [ $? -ne 0 ]; then
-    echo "Failed to install dotfiles"
-    exit 1
   fi
 fi

--- a/dotfiles/run.sh
+++ b/dotfiles/run.sh
@@ -20,4 +20,7 @@ if [ -n "$${DOTFILES_URI// }" ]; then
     DOTFILES_USER_HOME=$(eval echo ~"$DOTFILES_USER")
     sudo -u "$DOTFILES_USER" sh -c "'$CODER_BIN' dotfiles '$DOTFILES_URI' -y 2>&1 | tee '$DOTFILES_USER_HOME'/.dotfiles.log"
   fi
+  if [ $? -ne 0 ]; then
+    echo "Failed to install dotfiles"
+    exit 1  
 fi

--- a/dotfiles/run.sh
+++ b/dotfiles/run.sh
@@ -22,5 +22,6 @@ if [ -n "$${DOTFILES_URI// }" ]; then
   fi
   if [ $? -ne 0 ]; then
     echo "Failed to install dotfiles"
-    exit 1  
+    exit 1
+  fi
 fi


### PR DESCRIPTION
If the dotfiles installation (`coder dotfiles ...`) fails, the script still shows as successful in the Coder UI. This should bubble up any errors so that Coder (and the user) are aware that the installation failed.