### PR TITLE
fix: ensure Terraform is available for integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,11 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
+          # We're using the latest version of Bun for now, but it might be worth
+          # reconsidering. They've pushed breaking changes in patch releases
+          # that have broken our CI.
+          # Our PR where issues started to pop up: https://github.com/coder/modules/pull/383
+          # The Bun PR that broke things: https://github.com/oven-sh/bun/pull/16067
           bun-version: latest
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up job
+      - name: Check out code
         uses: actions/checkout@v4
-      - name: Set up Terraform (replace with Coder action if possible)
+      - name: Set up Terraform (REPLACE WITH CODER ACTION WHEN DONE)
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: 1.9.8
@@ -29,9 +29,9 @@ jobs:
           bun-version: latest
       - name: Install dependencies
         run: bun install
-      - name: Verify that Terraform is installed
+      - name: Verify that Terraform is installed (REMOVE WHEN DONE)
         run: which terraform
-      - name: Verify that Node.js is installed
+      - name: Verify that Node.js is installed (REMOVE WHEN DONE)
         run: which node
       - name: Run tests
         run: bun test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Set up Terraform (REPLACE WITH CODER ACTION WHEN DONE)
+      - name: Set up Terraform
         uses: coder/coder/.github/actions/setup-tf@main
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -26,10 +26,6 @@ jobs:
           bun-version: latest
       - name: Install dependencies
         run: bun install
-      - name: Verify that Terraform is installed (REMOVE WHEN DONE)
-        run: which terraform
-      - name: Verify that Node.js is installed (REMOVE WHEN DONE)
-        run: which node
       - name: Run tests
         run: bun test
   pretty:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Set up Terraform (REPLACE WITH CODER ACTION WHEN DONE)
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-        with:
-          terraform_version: 1.9.8
-          terraform_wrapper: false
+        uses: coder/coder/.github/actions/setup-tf@main
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,14 +16,21 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: coder/coder/.github/actions/setup-tf@main
-      - uses: oven-sh/setup-bun@v2
+      - name: Set up job
+        uses: actions/checkout@v4
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: 1.9.8
+          terraform_wrapper: false
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - name: Setup
+      - name: Install dependencies
         run: bun install
-      - run: bun test
+      - name: Run tests
+        run: bun test
   pretty:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,8 @@ jobs:
         run: bun install
       - name: Verify that Terraform is installed
         run: which terraform
+      - name: Verify that Node.js is installed
+        run: which node
       - name: Run tests
         run: bun test
   pretty:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Set up job
         uses: actions/checkout@v4
-      - name: Set up Terraform
+      - name: Set up Terraform (replace with Coder action if possible)
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: 1.9.8
@@ -29,6 +29,8 @@ jobs:
           bun-version: latest
       - name: Install dependencies
         run: bun install
+      - name: Verify that Terraform is installed
+        run: which terraform
       - name: Run tests
         run: bun test
   pretty:

--- a/kasmvnc/main.test.ts
+++ b/kasmvnc/main.test.ts
@@ -5,8 +5,6 @@ import {
   testRequiredVariables,
 } from "../test";
 
-console.log("DELETE ME BEFORE COMMITTING!!!!!");
-
 const allowedDesktopEnvs = ["xfce", "kde", "gnome", "lxde", "lxqt"] as const;
 type AllowedDesktopEnv = (typeof allowedDesktopEnvs)[number];
 

--- a/kasmvnc/main.test.ts
+++ b/kasmvnc/main.test.ts
@@ -5,6 +5,8 @@ import {
   testRequiredVariables,
 } from "../test";
 
+console.log("DELETE ME BEFORE COMMITTING!!!!!");
+
 const allowedDesktopEnvs = ["xfce", "kde", "gnome", "lxde", "lxqt"] as const;
 type AllowedDesktopEnv = (typeof allowedDesktopEnvs)[number];
 

--- a/setup.ts
+++ b/setup.ts
@@ -25,7 +25,7 @@ const removeOldContainers = async () => {
     "-a",
     "-q",
     "--filter",
-    `label=modules-test`,
+    "label=modules-test",
   ]);
   let containerIDsRaw = await readableStreamToText(proc.stdout);
   let exitCode = await proc.exited;

--- a/test.ts
+++ b/test.ts
@@ -198,13 +198,13 @@ export const runTerraformApply = async <TVars extends TerraformVariables>(
 ): Promise<TerraformState> => {
   const stateFile = `${dir}/${crypto.randomUUID()}.tfstate`;
 
-  const combinedEnv: Record<string, string | undefined> = {
+  const childEnv: Record<string, string | undefined> = {
     ...process.env,
     ...(customEnv ?? {}),
   };
   for (const [key, value] of Object.entries(vars) as [string, JsonValue][]) {
     if (value !== null) {
-      combinedEnv[`TF_VAR_${key}`] = String(value);
+      childEnv[`TF_VAR_${key}`] = String(value);
     }
   }
 
@@ -221,7 +221,7 @@ export const runTerraformApply = async <TVars extends TerraformVariables>(
     ],
     {
       cwd: dir,
-      env: combinedEnv,
+      env: childEnv,
       stderr: "pipe",
       stdout: "pipe",
     },

--- a/test.ts
+++ b/test.ts
@@ -202,7 +202,7 @@ export const runTerraformApply = async <TVars extends TerraformVariables>(
     ...process.env,
     ...(customEnv ?? {}),
   };
-  for (const [key, value] of Object.entries(vars)) {
+  for (const [key, value] of Object.entries(vars) as [string, JsonValue][]) {
     if (value !== null) {
       combinedEnv[`TF_VAR_${key}`] = String(value);
     }

--- a/test.ts
+++ b/test.ts
@@ -194,13 +194,18 @@ export const testRequiredVariables = <TVars extends TerraformVariables>(
 export const runTerraformApply = async <TVars extends TerraformVariables>(
   dir: string,
   vars: Readonly<TVars>,
-  env?: Record<string, string>,
+  customEnv?: Record<string, string>,
 ): Promise<TerraformState> => {
   const stateFile = `${dir}/${crypto.randomUUID()}.tfstate`;
 
-  const combinedEnv = env === undefined ? {} : { ...env };
+  const combinedEnv: Record<string, string | undefined> = {
+    ...process.env,
+    ...(customEnv ?? {}),
+  };
   for (const [key, value] of Object.entries(vars)) {
-    combinedEnv[`TF_VAR_${key}`] = String(value);
+    if (value !== null) {
+      combinedEnv[`TF_VAR_${key}`] = String(value);
+    }
   }
 
   const proc = spawn(


### PR DESCRIPTION
Closes #389

## Changes made
- Updated our test utilities to reference `process.env` explicitly, and pass it to our child processes
- Made some minor changes to CI and other TypeScript code as minor touch-ups

## Notes
- This was an issue that actually started on Bun's side. They made a breaking change to their `spawn` function, while also (1) pushing it out in a patch release, and (2) making no mention of the changes in their changelog. I'm not sure if we want to tighten up our Bun versioning going forward, but we can always do that in a later PR