### PR TITLE
fix(filebrowser): failed to set server_base_path if db is not existing

### DIFF
--- a/filebrowser/README.md
+++ b/filebrowser/README.md
@@ -15,7 +15,7 @@ A file browser for your workspace.
 module "filebrowser" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/modules/filebrowser/coder"
-  version  = "1.0.23"
+  version  = "1.0.29"
   agent_id = coder_agent.example.id
 }
 ```
@@ -30,7 +30,7 @@ module "filebrowser" {
 module "filebrowser" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/modules/filebrowser/coder"
-  version  = "1.0.23"
+  version  = "1.0.29"
   agent_id = coder_agent.example.id
   folder   = "/home/coder/project"
 }
@@ -42,7 +42,7 @@ module "filebrowser" {
 module "filebrowser" {
   count         = data.coder_workspace.me.start_count
   source        = "registry.coder.com/modules/filebrowser/coder"
-  version       = "1.0.23"
+  version       = "1.0.29"
   agent_id      = coder_agent.example.id
   database_path = ".config/filebrowser.db"
 }
@@ -54,7 +54,7 @@ module "filebrowser" {
 module "filebrowser" {
   count      = data.coder_workspace.me.start_count
   source     = "registry.coder.com/modules/filebrowser/coder"
-  version    = "1.0.23"
+  version    = "1.0.29"
   agent_id   = coder_agent.example.id
   agent_name = "main"
   subdomain  = false

--- a/filebrowser/main.test.ts
+++ b/filebrowser/main.test.ts
@@ -39,7 +39,7 @@ describe("filebrowser", async () => {
       "",
       "📂 Serving /root at http://localhost:13339 ",
       "",
-      "Running 'filebrowser --noauth --root /root --port 13339' ",
+      "Running 'filebrowser --noauth --root /root --port 13339 --baseurl ' ",
       "",
       "📝 Logs at /tmp/filebrowser.log",
     ]);
@@ -61,7 +61,7 @@ describe("filebrowser", async () => {
       "",
       "📂 Serving /root at http://localhost:13339 ",
       "",
-      "Running 'filebrowser --noauth --root /root --port 13339 -d .config/filebrowser.db' ",
+      "Running 'filebrowser --noauth --root /root --port 13339 -d .config/filebrowser.db --baseurl ' ",
       "",
       "📝 Logs at /tmp/filebrowser.log",
     ]);
@@ -75,7 +75,7 @@ describe("filebrowser", async () => {
     const output = await executeScriptInContainer(state, "alpine");
     expect(output.exitCode).toBe(0);
     expect(output.stdout).toEqual([
-      "\u001B[0;1mInstalling filebrowser ",
+      "\u001b[0;1mInstalling filebrowser ",
       "",
       "🥳 Installation complete! ",
       "",
@@ -83,7 +83,7 @@ describe("filebrowser", async () => {
       "",
       "📂 Serving /home/coder/project at http://localhost:13339 ",
       "",
-      "Running 'filebrowser --noauth --root /home/coder/project --port 13339' ",
+      "Running 'filebrowser --noauth --root /home/coder/project --port 13339 --baseurl ' ",
       "",
       "📝 Logs at /tmp/filebrowser.log",
     ]);
@@ -106,7 +106,7 @@ describe("filebrowser", async () => {
       "",
       "📂 Serving /root at http://localhost:13339 ",
       "",
-      "Running 'filebrowser --noauth --root /root --port 13339' ",
+      "Running 'filebrowser --noauth --root /root --port 13339 --baseurl /@default/default.main/apps/filebrowser' ",
       "",
       "📝 Logs at /tmp/filebrowser.log",
     ]);

--- a/filebrowser/run.sh
+++ b/filebrowser/run.sh
@@ -21,13 +21,11 @@ if [ "${DB_PATH}" != "filebrowser.db" ]; then
   DB_FLAG=" -d ${DB_PATH}"
 fi
 
-# set baseurl to be able to run if sudomain=false; if subdomain=true the SERVER_BASE_PATH value will be ""
-filebrowser config set --baseurl "${SERVER_BASE_PATH}"$${DB_FLAG} > ${LOG_PATH} 2>&1
-
 printf "📂 Serving $${ROOT_DIR} at http://localhost:${PORT} \n\n"
 
-printf "Running 'filebrowser --noauth --root $ROOT_DIR --port ${PORT}$${DB_FLAG}' \n\n"
+printf "Running 'filebrowser --noauth --root $ROOT_DIR --port ${PORT}$${DB_FLAG} -b ${SERVER_BASE_PATH}' \n\n"
 
-filebrowser --noauth --root $ROOT_DIR --port ${PORT}$${DB_FLAG} > ${LOG_PATH} 2>&1 &
+filebrowser --noauth --root $ROOT_DIR --port ${PORT}$${DB_FLAG} -b ${SERVER_BASE_PATH} > ${LOG_PATH} 2>&1 &
+
 
 printf "📝 Logs at ${LOG_PATH} \n\n"

--- a/filebrowser/run.sh
+++ b/filebrowser/run.sh
@@ -27,5 +27,4 @@ printf "Running 'filebrowser --noauth --root $ROOT_DIR --port ${PORT}$${DB_FLAG}
 
 filebrowser --noauth --root $ROOT_DIR --port ${PORT}$${DB_FLAG} --baseurl ${SERVER_BASE_PATH} > ${LOG_PATH} 2>&1 &
 
-
 printf "📝 Logs at ${LOG_PATH} \n\n"

--- a/filebrowser/run.sh
+++ b/filebrowser/run.sh
@@ -23,9 +23,9 @@ fi
 
 printf "📂 Serving $${ROOT_DIR} at http://localhost:${PORT} \n\n"
 
-printf "Running 'filebrowser --noauth --root $ROOT_DIR --port ${PORT}$${DB_FLAG} -b ${SERVER_BASE_PATH}' \n\n"
+printf "Running 'filebrowser --noauth --root $ROOT_DIR --port ${PORT}$${DB_FLAG} --baseurl ${SERVER_BASE_PATH}' \n\n"
 
-filebrowser --noauth --root $ROOT_DIR --port ${PORT}$${DB_FLAG} -b ${SERVER_BASE_PATH} > ${LOG_PATH} 2>&1 &
+filebrowser --noauth --root $ROOT_DIR --port ${PORT}$${DB_FLAG} --baseurl ${SERVER_BASE_PATH} > ${LOG_PATH} 2>&1 &
 
 
 printf "📝 Logs at ${LOG_PATH} \n\n"


### PR DESCRIPTION
On the first start, the DB does not exist and the "filebrowser config set --baseurl" will failed. filebrowser was starting with the wrong baseurl (subdomain=false). it starts correctly on the second try if the db was persisted. this fix set the correct baseurl even if the db was not existing