### PR TITLE
fix(filebrowser): configure before running

### DIFF
--- a/filebrowser/run.sh
+++ b/filebrowser/run.sh
@@ -24,7 +24,7 @@ fi
 # Check if filebrowser db exists
 if [ ! -f ${DB_PATH} ]; then
   filebrowser $DB_FLAG config init >> ${LOG_PATH} 2>&1
-  filebrowser $DB_FLAG config set --baseurl ${SERVER_BASE_PATH} --port ${PORT} --auth.method=noauth --root $ROOT_DIR >> ${LOG_PATH} 2>&1
+  filebrowser $DB_FLAG config set --baseurl=${SERVER_BASE_PATH} --port=${PORT} --auth.method=noauth --root=$ROOT_DIR >> ${LOG_PATH} 2>&1
   filebrowser $DB_FLAG users add admin "" --perm.admin=true >> ${LOG_PATH} 2>&1
 fi
 

--- a/filebrowser/run.sh
+++ b/filebrowser/run.sh
@@ -11,7 +11,7 @@ fi
 
 printf "🥳 Installation complete! \n\n"
 
-printf "👷 Starting filebrowser in background... \n\n"
+printf "🛠️  Configuring filebrowser \n\n"
 
 ROOT_DIR=${FOLDER}
 ROOT_DIR=$${ROOT_DIR/\~/$HOME}
@@ -21,10 +21,20 @@ if [ "${DB_PATH}" != "filebrowser.db" ]; then
   DB_FLAG=" -d ${DB_PATH}"
 fi
 
+# Check if filebrowser db exists
+if [ ! -f ${DB_PATH} ]; then
+  filebrowser $DB_FLAG config init > ${LOG_PATH} 2>&1
+  filebrowser $DB_FLAG config set  --baseurl ${SERVER_BASE_PATH} --port ${PORT} --auth.method=noauth --root $ROOT_DIR > ${LOG_PATH} 2>&1
+  filebrowser $DB_FLAG users add admin "" --perm.admin=true > ${LOG_PATH} 2>&1
+fi
+
+printf "👷 Starting filebrowser in background... \n\n"
+
+
 printf "📂 Serving $${ROOT_DIR} at http://localhost:${PORT} \n\n"
 
-printf "Running 'filebrowser --noauth --root $ROOT_DIR --port ${PORT}$${DB_FLAG} --baseurl ${SERVER_BASE_PATH}' \n\n"
+printf "Running 'filebrowser $DB_FLAG' \n\n"
 
-filebrowser --noauth --root $ROOT_DIR --port ${PORT}$${DB_FLAG} --baseurl ${SERVER_BASE_PATH} > ${LOG_PATH} 2>&1 &
+filebrowser $DB_FLAG > ${LOG_PATH} 2>&1 &
 
 printf "📝 Logs at ${LOG_PATH} \n\n"

--- a/filebrowser/run.sh
+++ b/filebrowser/run.sh
@@ -23,9 +23,9 @@ fi
 
 # Check if filebrowser db exists
 if [ ! -f ${DB_PATH} ]; then
-  filebrowser $DB_FLAG config init > ${LOG_PATH} 2>&1
-  filebrowser $DB_FLAG config set  --baseurl ${SERVER_BASE_PATH} --port ${PORT} --auth.method=noauth --root $ROOT_DIR > ${LOG_PATH} 2>&1
-  filebrowser $DB_FLAG users add admin "" --perm.admin=true > ${LOG_PATH} 2>&1
+  filebrowser $DB_FLAG config init >> ${LOG_PATH} 2>&1
+  filebrowser $DB_FLAG config set --baseurl ${SERVER_BASE_PATH} --port ${PORT} --auth.method=noauth --root $ROOT_DIR >> ${LOG_PATH} 2>&1
+  filebrowser $DB_FLAG users add admin "" --perm.admin=true >> ${LOG_PATH} 2>&1
 fi
 
 printf "👷 Starting filebrowser in background... \n\n"
@@ -35,6 +35,6 @@ printf "📂 Serving $${ROOT_DIR} at http://localhost:${PORT} \n\n"
 
 printf "Running 'filebrowser $DB_FLAG' \n\n"
 
-filebrowser $DB_FLAG > ${LOG_PATH} 2>&1 &
+filebrowser $DB_FLAG >> ${LOG_PATH} 2>&1 &
 
 printf "📝 Logs at ${LOG_PATH} \n\n"

--- a/filebrowser/run.sh
+++ b/filebrowser/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BOLD='\033[0;1m'
+BOLD='\033[[0;1m'
 
 printf "$${BOLD}Installing filebrowser \n\n"
 
@@ -17,12 +17,12 @@ ROOT_DIR=${FOLDER}
 ROOT_DIR=$${ROOT_DIR/\~/$HOME}
 
 DB_FLAG=""
-if [ "${DB_PATH}" != "filebrowser.db" ]; then
+if [[ "${DB_PATH}" != "filebrowser.db" ]]; then
   DB_FLAG=" -d ${DB_PATH}"
 fi
 
 # Check if filebrowser db exists
-if [ ! -f ${DB_PATH} ]; then
+if [[ ! -f ${DB_PATH} ]]; then
   filebrowser $DB_FLAG config init  2>&1 | tee -a ${LOG_PATH}
   filebrowser $DB_FLAG users add admin "" --perm.admin=true --viewMode=mosaic 2>&1 | tee -a ${LOG_PATH} 
 fi

--- a/filebrowser/run.sh
+++ b/filebrowser/run.sh
@@ -24,9 +24,10 @@ fi
 # Check if filebrowser db exists
 if [ ! -f ${DB_PATH} ]; then
   filebrowser $DB_FLAG config init >> ${LOG_PATH} 2>&1
-  filebrowser $DB_FLAG config set --baseurl=${SERVER_BASE_PATH} --port=${PORT} --auth.method=noauth --root=$ROOT_DIR >> ${LOG_PATH} 2>&1
-  filebrowser $DB_FLAG users add admin "" --perm.admin=true >> ${LOG_PATH} 2>&1
+  filebrowser $DB_FLAG users add admin "" --perm.admin=true --viewMode=mosaic >> ${LOG_PATH} 2>&1
 fi
+
+filebrowser $DB_FLAG config set --baseurl=${SERVER_BASE_PATH} --port=${PORT} --auth.method=noauth --root=$ROOT_DIR >> ${LOG_PATH} 2>&1
 
 printf "👷 Starting filebrowser in background... \n\n"
 

--- a/filebrowser/run.sh
+++ b/filebrowser/run.sh
@@ -16,26 +16,22 @@ printf "🛠️  Configuring filebrowser \n\n"
 ROOT_DIR=${FOLDER}
 ROOT_DIR=$${ROOT_DIR/\~/$HOME}
 
-DB_FLAG=""
-if [[ "${DB_PATH}" != "filebrowser.db" ]]; then
-  DB_FLAG=" -d ${DB_PATH}"
-fi
+echo "DB_PATH: ${DB_PATH}"
+
+export FB_DATABASE="${DB_PATH}"
 
 # Check if filebrowser db exists
-if [[ ! -f ${DB_PATH} ]]; then
-  filebrowser $DB_FLAG config init  2>&1 | tee -a ${LOG_PATH}
-  filebrowser $DB_FLAG users add admin "" --perm.admin=true --viewMode=mosaic 2>&1 | tee -a ${LOG_PATH} 
+if [[ ! -f "${DB_PATH}" ]]; then
+  filebrowser config init  2>&1 | tee -a ${LOG_PATH}
+  filebrowser users add admin "" --perm.admin=true --viewMode=mosaic 2>&1 | tee -a ${LOG_PATH} 
 fi
 
-filebrowser $DB_FLAG config set --baseurl=${SERVER_BASE_PATH} --port=${PORT} --auth.method=noauth --root=$ROOT_DIR 2>&1 | tee -a ${LOG_PATH} 
+filebrowser config set --baseurl=${SERVER_BASE_PATH} --port=${PORT} --auth.method=noauth --root=$ROOT_DIR 2>&1 | tee -a ${LOG_PATH} 
 
 printf "👷 Starting filebrowser in background... \n\n"
 
-
 printf "📂 Serving $${ROOT_DIR} at http://localhost:${PORT} \n\n"
 
-printf "Running 'filebrowser %s' \n\n" "$DB_FLAG"
-
-filebrowser $DB_FLAG >> ${LOG_PATH} 2>&1 &
+filebrowser >> ${LOG_PATH} 2>&1 &
 
 printf "📝 Logs at ${LOG_PATH} \n\n"

--- a/filebrowser/run.sh
+++ b/filebrowser/run.sh
@@ -23,18 +23,18 @@ fi
 
 # Check if filebrowser db exists
 if [ ! -f ${DB_PATH} ]; then
-  filebrowser $DB_FLAG config init >> ${LOG_PATH} 2>&1
-  filebrowser $DB_FLAG users add admin "" --perm.admin=true --viewMode=mosaic >> ${LOG_PATH} 2>&1
+  filebrowser $DB_FLAG config init  2>&1 | tee -a ${LOG_PATH}
+  filebrowser $DB_FLAG users add admin "" --perm.admin=true --viewMode=mosaic 2>&1 | tee -a ${LOG_PATH} 
 fi
 
-filebrowser $DB_FLAG config set --baseurl=${SERVER_BASE_PATH} --port=${PORT} --auth.method=noauth --root=$ROOT_DIR >> ${LOG_PATH} 2>&1
+filebrowser $DB_FLAG config set --baseurl=${SERVER_BASE_PATH} --port=${PORT} --auth.method=noauth --root=$ROOT_DIR 2>&1 | tee -a ${LOG_PATH} 
 
 printf "👷 Starting filebrowser in background... \n\n"
 
 
 printf "📂 Serving $${ROOT_DIR} at http://localhost:${PORT} \n\n"
 
-printf "Running 'filebrowser $DB_FLAG' \n\n"
+printf "Running 'filebrowser %s' \n\n" "$DB_FLAG"
 
 filebrowser $DB_FLAG >> ${LOG_PATH} 2>&1 &
 


### PR DESCRIPTION
Fixes #399 

Instead of trying to cram the config into one command we check if the db exists, if not initialize it then configure the various values before starting the app.