### PR TITLE
feat(vscode-web): allow pinning vscode-web binary to a specific commit ID

### DIFF
--- a/vscode-web/README.md
+++ b/vscode-web/README.md
@@ -15,7 +15,7 @@ Automatically install [Visual Studio Code Server](https://code.visualstudio.com/
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/modules/vscode-web/coder"
-  version        = "1.0.29"
+  version        = "1.0.30"
   agent_id       = coder_agent.example.id
   accept_license = true
 }
@@ -31,7 +31,7 @@ module "vscode-web" {
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/modules/vscode-web/coder"
-  version        = "1.0.29"
+  version        = "1.0.30"
   agent_id       = coder_agent.example.id
   install_prefix = "/home/coder/.vscode-web"
   folder         = "/home/coder"
@@ -45,7 +45,7 @@ module "vscode-web" {
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/modules/vscode-web/coder"
-  version        = "1.0.29"
+  version        = "1.0.30"
   agent_id       = coder_agent.example.id
   extensions     = ["github.copilot", "ms-python.python", "ms-toolsai.jupyter"]
   accept_license = true
@@ -60,7 +60,7 @@ Configure VS Code's [settings.json](https://code.visualstudio.com/docs/getstarte
 module "vscode-web" {
   count      = data.coder_workspace.me.start_count
   source     = "registry.coder.com/modules/vscode-web/coder"
-  version    = "1.0.29"
+  version    = "1.0.30"
   agent_id   = coder_agent.example.id
   extensions = ["dracula-theme.theme-dracula"]
   settings = {

--- a/vscode-web/main.tf
+++ b/vscode-web/main.tf
@@ -157,7 +157,7 @@ resource "coder_script" "vscode-web" {
     FOLDER : var.folder,
     AUTO_INSTALL_EXTENSIONS : var.auto_install_extensions,
     SERVER_BASE_PATH : local.server_base_path,
-    VSCODE_WEB_COMMIT_ID : var.vscode_web_commit_id, 
+    VSCODE_WEB_COMMIT_ID : var.vscode_web_commit_id,
   })
   run_on_start = true
 

--- a/vscode-web/main.tf
+++ b/vscode-web/main.tf
@@ -59,6 +59,12 @@ variable "install_prefix" {
   default     = "/tmp/vscode-web"
 }
 
+variable "vscode_web_commit_id" {
+  type        = string
+  description = "Specify the commit ID of the VS Code Web binary to pin to a specific version. If left empty, the latest stable version is used."
+  default     = ""
+}
+
 variable "extensions" {
   type        = list(string)
   description = "A list of extensions to install."
@@ -151,6 +157,7 @@ resource "coder_script" "vscode-web" {
     FOLDER : var.folder,
     AUTO_INSTALL_EXTENSIONS : var.auto_install_extensions,
     SERVER_BASE_PATH : local.server_base_path,
+    VSCODE_WEB_COMMIT_ID : var.vscode_web_commit_id, 
   })
   run_on_start = true
 

--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -59,8 +59,15 @@ case "$ARCH" in
     ;;
 esac
 
-HASH=$(curl -fsSL https://update.code.visualstudio.com/api/commits/stable/server-linux-$ARCH-web | cut -d '"' -f 2)
-output=$(curl -fsSL https://vscode.download.prss.microsoft.com/dbazure/download/stable/$HASH/vscode-server-linux-$ARCH-web.tar.gz | tar -xz -C ${INSTALL_PREFIX} --strip-components 1)
+# Check if a specific VS Code Web commit ID was provided
+if [ -n "${VSCODE_WEB_COMMIT_ID}" ]; then
+  HASH="${VSCODE_WEB_COMMIT_ID}"
+else
+  HASH=$(curl -fsSL https://update.code.visualstudio.com/api/commits/stable/server-linux-$ARCH-web | cut -d '"' -f 2)
+fi
+printf "$${BOLD}VS Code Web commit id version $HASH.\n"
+
+output=$(curl -fsSL "https://vscode.download.prss.microsoft.com/dbazure/download/stable/$HASH/vscode-server-linux-$ARCH-web.tar.gz" | tar -xz -C "${INSTALL_PREFIX}" --strip-components 1)
 
 if [ $? -ne 0 ]; then
   echo "Failed to install Microsoft Visual Studio Code Server: $output"


### PR DESCRIPTION
Adds support for specifying a commit ID to pin the vscode-web binary version in the module.