### PR TITLE
feat(vscode-web): allow pinning vscode-web version to a specific commit ID

### DIFF
--- a/vscode-web/README.md
+++ b/vscode-web/README.md
@@ -76,11 +76,11 @@ By default, this module installs the latest. To pin a specific version, retrieve
 
 ```tf
 module "vscode-web" {
-  count      = data.coder_workspace.me.start_count
-  source     = "registry.coder.com/modules/vscode-web/coder"
-  version    = "1.0.30"
-  agent_id   = coder_agent.example.id
-  commit_id  = "e54c774e0add60467559eb0d1e229c6452cf8447"
+  count          = data.coder_workspace.me.start_count
+  source         = "registry.coder.com/modules/vscode-web/coder"
+  version        = "1.0.30"
+  agent_id       = coder_agent.example.id
+  commit_id      = "e54c774e0add60467559eb0d1e229c6452cf8447"
   accept_license = true
 }
 ```

--- a/vscode-web/README.md
+++ b/vscode-web/README.md
@@ -15,7 +15,7 @@ Automatically install [Visual Studio Code Server](https://code.visualstudio.com/
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/modules/vscode-web/coder"
-  version        = "1.0.29"
+  version        = "1.0.30"
   agent_id       = coder_agent.example.id
   accept_license = true
 }
@@ -31,7 +31,7 @@ module "vscode-web" {
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/modules/vscode-web/coder"
-  version        = "1.0.29"
+  version        = "1.0.30"
   agent_id       = coder_agent.example.id
   install_prefix = "/home/coder/.vscode-web"
   folder         = "/home/coder"
@@ -45,7 +45,7 @@ module "vscode-web" {
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/modules/vscode-web/coder"
-  version        = "1.0.29"
+  version        = "1.0.30"
   agent_id       = coder_agent.example.id
   extensions     = ["github.copilot", "ms-python.python", "ms-toolsai.jupyter"]
   accept_license = true
@@ -60,12 +60,27 @@ Configure VS Code's [settings.json](https://code.visualstudio.com/docs/getstarte
 module "vscode-web" {
   count      = data.coder_workspace.me.start_count
   source     = "registry.coder.com/modules/vscode-web/coder"
-  version    = "1.0.29"
+  version    = "1.0.30"
   agent_id   = coder_agent.example.id
   extensions = ["dracula-theme.theme-dracula"]
   settings = {
     "workbench.colorTheme" = "Dracula"
   }
+  accept_license = true
+}
+```
+
+### Pin a specific VS Code Web version
+
+By default, this module installs the latest. To pin a specific version, retrieve the commit ID from the [VS Code Update API](https://update.code.visualstudio.com/api/commits/stable/server-linux-x64-web) and verify its corresponding release on the [VS Code GitHub Releases](https://github.com/microsoft/vscode/releases).
+
+```tf
+module "vscode-web" {
+  count      = data.coder_workspace.me.start_count
+  source     = "registry.coder.com/modules/vscode-web/coder"
+  version    = "1.0.30"
+  agent_id   = coder_agent.example.id
+  commit_id  = "e54c774e0add60467559eb0d1e229c6452cf8447"
   accept_license = true
 }
 ```

--- a/vscode-web/main.tf
+++ b/vscode-web/main.tf
@@ -59,6 +59,12 @@ variable "install_prefix" {
   default     = "/tmp/vscode-web"
 }
 
+variable "commit_id" {
+  type        = string
+  description = "Specify the commit ID of the VS Code Web binary to pin to a specific version. If left empty, the latest stable version is used."
+  default     = ""
+}
+
 variable "extensions" {
   type        = list(string)
   description = "A list of extensions to install."
@@ -151,6 +157,7 @@ resource "coder_script" "vscode-web" {
     FOLDER : var.folder,
     AUTO_INSTALL_EXTENSIONS : var.auto_install_extensions,
     SERVER_BASE_PATH : local.server_base_path,
+    COMMIT_ID : var.commit_id,
   })
   run_on_start = true
 

--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -59,8 +59,15 @@ case "$ARCH" in
     ;;
 esac
 
-HASH=$(curl -fsSL https://update.code.visualstudio.com/api/commits/stable/server-linux-$ARCH-web | cut -d '"' -f 2)
-output=$(curl -fsSL https://vscode.download.prss.microsoft.com/dbazure/download/stable/$HASH/vscode-server-linux-$ARCH-web.tar.gz | tar -xz -C ${INSTALL_PREFIX} --strip-components 1)
+# Check if a specific VS Code Web commit ID was provided
+if [ -n "${COMMIT_ID}" ]; then
+  HASH="${COMMIT_ID}"
+else
+  HASH=$(curl -fsSL https://update.code.visualstudio.com/api/commits/stable/server-linux-$ARCH-web | cut -d '"' -f 2)
+fi
+printf "$${BOLD}VS Code Web commit id version $HASH.\n"
+
+output=$(curl -fsSL "https://vscode.download.prss.microsoft.com/dbazure/download/stable/$HASH/vscode-server-linux-$ARCH-web.tar.gz" | tar -xz -C "${INSTALL_PREFIX}" --strip-components 1)
 
 if [ $? -ne 0 ]; then
   echo "Failed to install Microsoft Visual Studio Code Server: $output"


### PR DESCRIPTION
Adds support for specifying a commit ID to pin the vscode-web version in the module with added example in README.