### PR TITLE
fix(jupyterlab): don't use `-q` option

### DIFF
--- a/jupyterlab/README.md
+++ b/jupyterlab/README.md
@@ -17,7 +17,7 @@ A module that adds JupyterLab in your Coder template.
 module "jupyterlab" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/modules/jupyterlab/coder"
-  version  = "1.0.23"
+  version  = "1.0.30"
   agent_id = coder_agent.example.id
 }
 ```

--- a/jupyterlab/run.sh
+++ b/jupyterlab/run.sh
@@ -18,7 +18,7 @@ if ! command -v jupyter-lab > /dev/null 2>&1; then
     exit 1
   fi
   # install jupyterlab
-  pipx install -q jupyterlab
+  pipx install jupyterlab > /dev/null 2>&1
   printf "%s\n\n" "🥳 jupyterlab has been installed"
 else
   printf "%s\n\n" "🥳 jupyterlab is already installed"


### PR DESCRIPTION
On Ubuntu 22.04, pipx (via `apt install`) does not have the `-q` option. 
The description that depends on the pipx version should be reduced.