### PR TITLE
feat(jfrog-token): update module to accept username

### DIFF
--- a/jfrog-token/README.md
+++ b/jfrog-token/README.md
@@ -15,7 +15,7 @@ Install the JF CLI and authenticate package managers with Artifactory using Arti
 ```tf
 module "jfrog" {
   source                   = "registry.coder.com/modules/jfrog-token/coder"
-  version                  = "1.0.19"
+  version                  = "1.0.30"
   agent_id                 = coder_agent.example.id
   jfrog_url                = "https://XXXX.jfrog.io"
   artifactory_access_token = var.artifactory_access_token
@@ -42,7 +42,7 @@ For detailed instructions, please see this [guide](https://coder.com/docs/v2/lat
 ```tf
 module "jfrog" {
   source                   = "registry.coder.com/modules/jfrog-token/coder"
-  version                  = "1.0.19"
+  version                  = "1.0.30"
   agent_id                 = coder_agent.example.id
   jfrog_url                = "https://YYYY.jfrog.io"
   artifactory_access_token = var.artifactory_access_token # An admin access token
@@ -75,7 +75,7 @@ The [JFrog extension](https://open-vsx.org/extension/JFrog/jfrog-vscode-extensio
 ```tf
 module "jfrog" {
   source                   = "registry.coder.com/modules/jfrog-token/coder"
-  version                  = "1.0.19"
+  version                  = "1.0.30"
   agent_id                 = coder_agent.example.id
   jfrog_url                = "https://XXXX.jfrog.io"
   artifactory_access_token = var.artifactory_access_token
@@ -95,7 +95,7 @@ data "coder_workspace" "me" {}
 
 module "jfrog" {
   source                   = "registry.coder.com/modules/jfrog-token/coder"
-  version                  = "1.0.19"
+  version                  = "1.0.30"
   agent_id                 = coder_agent.example.id
   jfrog_url                = "https://XXXX.jfrog.io"
   artifactory_access_token = var.artifactory_access_token

--- a/jfrog-token/main.test.ts
+++ b/jfrog-token/main.test.ts
@@ -20,6 +20,7 @@ describe("jfrog-token", async () => {
     refreshable?: boolean;
     expires_in?: number;
     username_field?: string;
+    username?: string;
     jfrog_server_id?: string;
     configure_code_server?: boolean;
   };

--- a/jfrog-token/main.tf
+++ b/jfrog-token/main.tf
@@ -68,6 +68,12 @@ variable "username_field" {
   }
 }
 
+variable "username" {
+  type        = string
+  description = "Username to use for Artifactory. Overrides the field specified in `username_field`"
+  default     = null
+}
+
 variable "agent_id" {
   type        = string
   description = "The ID of a Coder agent."
@@ -99,8 +105,8 @@ variable "package_managers" {
 }
 
 locals {
-  # The username field to use for artifactory
-  username   = var.username_field == "email" ? data.coder_workspace_owner.me.email : data.coder_workspace_owner.me.name
+  # The username to use for artifactory
+  username   = coalesce(var.username, var.username_field == "email" ? data.coder_workspace_owner.me.email : data.coder_workspace_owner.me.name)
   jfrog_host = split("://", var.jfrog_url)[1]
   common_values = {
     JFROG_URL                = var.jfrog_url


### PR DESCRIPTION
## Description

Adds the options to specify a username for the Jfrog user as an input to the module. 

This is useful in cases where Coder usernames and Jfrog usernames are different. 

## Test plan

Ran `bun` tests for the module. 