### PR TITLE
Use VSCode Code CLI instead of VSCode code-server to run VSCode Web

### DIFF
--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -5,21 +5,19 @@ EXTENSIONS=("${EXTENSIONS}")
 VSCODE_CLI="${INSTALL_PREFIX}/code"
 
 # Set extension directory
-EXTENSION_ARG=""
 if [ -n "${EXTENSIONS_DIR}" ]; then
-  EXTENSION_ARG="--extensions-dir=${EXTENSIONS_DIR}"
+  EXTENSIONS_DIR="--extensions-dir=${EXTENSIONS_DIR}"
 fi
 
 # Set extension directory
-SERVER_BASE_PATH_ARG=""
 if [ -n "${SERVER_BASE_PATH}" ]; then
-  SERVER_BASE_PATH_ARG="--server-base-path=${SERVER_BASE_PATH}"
+  SERVER_BASE_PATH="--server-base-path=${SERVER_BASE_PATH}"
 fi
 
 run_vscode_web() {
-  echo "👷 Running $VSCODE_CLI serve-web $EXTENSION_ARG $SERVER_BASE_PATH_ARG --port ${PORT} --host 127.0.0.1 --accept-server-license-terms --without-connection-token in the background..."
+  echo "👷 Running $VSCODE_CLI serve-web $EXTENSIONS_DIR $SERVER_BASE_PATH_ARG --port ${PORT} --host 127.0.0.1 --accept-server-license-terms --without-connection-token in the background..."
   echo "Check logs at ${LOG_PATH}!"
-  "$VSCODE_CLI" serve-web ${EXTENSION_ARG:+$EXTENSION_ARG} ${SERVER_BASE_PATH_ARG:+$SERVER_BASE_PATH_ARG} --port "${PORT}" --host 127.0.0.1 --accept-server-license-terms --without-connection-token > "${LOG_PATH}" 2>&1 &
+  "$VSCODE_CLI" serve-web ${EXTENSIONS_DIR} ${SERVER_BASE_PATH} --port "${PORT}" --host 127.0.0.1 --accept-server-license-terms --without-connection-token > "${LOG_PATH}" 2>&1 &
 }
 
 # Check if the settings file exists...
@@ -96,7 +94,7 @@ install_extension() {
       continue
     fi
     printf "🧩 Installing extension $${CODE}$extension$${RESET}...\n"
-    output=$($VSCODE_WEB "$EXTENSION_ARG" --install-extension "$extension" --force)
+    output=$($VSCODE_WEB $EXTENSIONS_DIR --install-extension "$extension" --force)
     if [ $? -ne 0 ]; then
       echo "Failed to install extension: $extension: $output"
     fi
@@ -116,7 +114,7 @@ install_extension() {
         # Use sed to remove single-line comments before parsing with jq
         extensions=$(sed 's|//.*||g' "$WORKSPACE_DIR"/.vscode/extensions.json | jq -r '.recommendations[]')
         for extension in $extensions; do
-          $VSCODE_WEB "$EXTENSION_ARG" --install-extension "$extension" --force
+          $VSCODE_WEB $EXTENSIONS_DIR --install-extension "$extension" --force
         done
       fi
     fi

--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -20,7 +20,8 @@ fi
 run_vscode_web() {
   echo "👷 Running $VSCODE_CLI serve-web $EXTENSION_ARG $SERVER_BASE_PATH_ARG --port ${PORT} --host 127.0.0.1 --accept-server-license-terms --without-connection-token in the background..."
   echo "Check logs at ${LOG_PATH}!"
-  "$VSCODE_CLI" serve-web "$EXTENSION_ARG" "$SERVER_BASE_PATH_ARG" --port "${PORT}" --host 127.0.0.1 --accept-server-license-terms --without-connection-token > "${LOG_PATH}" 2>&1 &
+  # Todo: Add EXTENSION_ARG and SERVER_BASE_PATH_ARG
+  "$VSCODE_CLI" serve-web --port "${PORT}" --host 127.0.0.1 --accept-server-license-terms --without-connection-token > "${LOG_PATH}" 2>&1 &
 }
 
 # Check if the settings file exists...

--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -5,19 +5,21 @@ EXTENSIONS=("${EXTENSIONS}")
 VSCODE_CLI="${INSTALL_PREFIX}/code"
 
 # Set extension directory
+EXTENSION_ARG=""
 if [ -n "${EXTENSIONS_DIR}" ]; then
-  EXTENSIONS_DIR="--extensions-dir=${EXTENSIONS_DIR}"
+  EXTENSION_ARG="--extensions-dir=${EXTENSIONS_DIR}"
 fi
 
 # Set extension directory
+SERVER_BASE_PATH_ARG=""
 if [ -n "${SERVER_BASE_PATH}" ]; then
-  SERVER_BASE_PATH="--server-base-path=${SERVER_BASE_PATH}"
+  SERVER_BASE_PATH_ARG="--server-base-path=${SERVER_BASE_PATH}"
 fi
 
 run_vscode_web() {
-  echo "👷 Running $VSCODE_CLI serve-web $EXTENSIONS_DIR $SERVER_BASE_PATH_ARG --port ${PORT} --host 127.0.0.1 --accept-server-license-terms --without-connection-token in the background..."
+  echo "👷 Running $VSCODE_CLI serve-web $EXTENSION_ARG $SERVER_BASE_PATH_ARG --port ${PORT} --host 127.0.0.1 --accept-server-license-terms --without-connection-token in the background..."
   echo "Check logs at ${LOG_PATH}!"
-  "$VSCODE_CLI" serve-web ${EXTENSIONS_DIR} ${SERVER_BASE_PATH} --port "${PORT}" --host 127.0.0.1 --accept-server-license-terms --without-connection-token > "${LOG_PATH}" 2>&1 &
+  "$VSCODE_CLI" serve-web $EXTENSION_ARG $SERVER_BASE_PATH_ARG --port "${PORT}" --host 127.0.0.1 --accept-server-license-terms --without-connection-token > "${LOG_PATH}" 2>&1 &
 }
 
 # Check if the settings file exists...

--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -69,7 +69,7 @@ fi
 printf "$${BOLD}VS Code Web commit id version $HASH.\n"
 
 # Todo: Support download for other OS
-output=$(curl -fsSL "https://vscode.download.prss.microsoft.com/dbazure/download/stable/$HASH/vscode_cli_alpine_x64_cli.tar.gz" | tar -xz -C "${INSTALL_PREFIX}" --strip-components 1)
+output=$(curl -fsSL "https://vscode.download.prss.microsoft.com/dbazure/download/stable/$HASH/vscode_cli_alpine_x64_cli.tar.gz" | tar -xz -C "${INSTALL_PREFIX}")
 
 if [ $? -ne 0 ]; then
   echo "Failed to install Microsoft Visual Studio Code Server: $output"

--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -123,6 +123,7 @@ install_extension() {
       fi
     fi
   fi
+  printf "✅ VSCode Web Extension installed.\n"
 }
 
 run_vscode_web

--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -80,7 +80,8 @@ printf "$${BOLD}VS Code Web has been installed.\n"
 
 VSCODE_WEB=~/.vscode/cli/serve-web/$HASH/bin/code-server
 install_extension() {
-  echo "Wait for $VSCODE_WEB."
+  # code serve-web auto download code-server by health check trigger.
+  echo "Download code-server to $VSCODE_WEB."
   
   while true; do
     if [ -f "$VSCODE_WEB" ]; then
@@ -88,7 +89,7 @@ install_extension() {
         break
     fi
     echo "Wait for $VSCODE_WEB."
-    sleep 5
+    sleep 30
   done
   
   # Install each extension...
@@ -123,8 +124,8 @@ install_extension() {
       fi
     fi
   fi
-  printf "✅ VSCode Web Extension installed.\n"
 }
 
 run_vscode_web
 install_extension
+printf "✅ VSCode Web installed.\n"

--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -4,22 +4,21 @@ BOLD='\033[0;1m'
 EXTENSIONS=("${EXTENSIONS}")
 VSCODE_CLI="${INSTALL_PREFIX}/code"
 
+ARGS=()
 # Set extension directory
-EXTENSION_ARG=""
 if [ -n "${EXTENSIONS_DIR}" ]; then
-  EXTENSION_ARG="--extensions-dir=${EXTENSIONS_DIR}"
+  ARGS+=("--extensions-dir=${EXTENSIONS_DIR}")
 fi
 
 # Set extension directory
-SERVER_BASE_PATH_ARG=""
 if [ -n "${SERVER_BASE_PATH}" ]; then
-  SERVER_BASE_PATH_ARG="--server-base-path=${SERVER_BASE_PATH}"
+  ARGS+=("--server-base-path=${SERVER_BASE_PATH}")
 fi
 
 run_vscode_web() {
   echo "👷 Running $VSCODE_CLI serve-web $EXTENSION_ARG $SERVER_BASE_PATH_ARG --port ${PORT} --host 127.0.0.1 --accept-server-license-terms --without-connection-token in the background..."
   echo "Check logs at ${LOG_PATH}!"
-  "$VSCODE_CLI" serve-web ${EXTENSION_ARG} ${SERVER_BASE_PATH_ARG} --port "${PORT}" --host 127.0.0.1 --accept-server-license-terms --without-connection-token > "${LOG_PATH}" 2>&1 &
+  "$VSCODE_CLI" serve-web "${ARGS[@]}" --port "${PORT}" --host 127.0.0.1 --accept-server-license-terms --without-connection-token > "${LOG_PATH}" 2>&1 &
 }
 
 # Check if the settings file exists...

--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -77,38 +77,49 @@ if [ $? -ne 0 ]; then
 fi
 printf "$${BOLD}VS Code Web has been installed.\n"
 
-# Todo: Support download extension later
-# Install each extension...
-#IFS=',' read -r -a EXTENSIONLIST <<< "$${EXTENSIONS}"
-#for extension in "$${EXTENSIONLIST[@]}"; do
-#  if [ -z "$extension" ]; then
-#    continue
-#  fi
-#  printf "🧩 Installing extension $${CODE}$extension$${RESET}...\n"
-#  output=$($VSCODE_WEB "$EXTENSION_ARG" --install-extension "$extension" --force)
-#  if [ $? -ne 0 ]; then
-#    echo "Failed to install extension: $extension: $output"
-#  fi
-#done
-
-#if [ "${AUTO_INSTALL_EXTENSIONS}" = true ]; then
-#  if ! command -v jq > /dev/null; then
-#    echo "jq is required to install extensions from a workspace file."
-#  else
-#    WORKSPACE_DIR="$HOME"
-#    if [ -n "${FOLDER}" ]; then
-#      WORKSPACE_DIR="${FOLDER}"
-#    fi
-#
-#    if [ -f "$WORKSPACE_DIR/.vscode/extensions.json" ]; then
-#      printf "🧩 Installing extensions from %s/.vscode/extensions.json...\n" "$WORKSPACE_DIR"
-#      # Use sed to remove single-line comments before parsing with jq
-#      extensions=$(sed 's|//.*||g' "$WORKSPACE_DIR"/.vscode/extensions.json | jq -r '.recommendations[]')
-#      for extension in $extensions; do
-#        $VSCODE_WEB "$EXTENSION_ARG" --install-extension "$extension" --force
-#      done
-#    fi
-#  fi
-#fi
+VSCODE_WEB="~/.vscode/cli/serve-web/$HASH/bin/code-server"
+install_extension() {
+  while true; do
+    if [ -f "$VSCODE_WEB" ]; then
+        echo "$VSCODE_WEB exists."
+        break
+    fi
+    sleep 5
+  done
+  
+  # Install each extension...
+  IFS=',' read -r -a EXTENSIONLIST <<< "$${EXTENSIONS}"
+  for extension in "$${EXTENSIONLIST[@]}"; do
+    if [ -z "$extension" ]; then
+      continue
+    fi
+    printf "🧩 Installing extension $${CODE}$extension$${RESET}...\n"
+    output=$($VSCODE_WEB "$EXTENSION_ARG" --install-extension "$extension" --force)
+    if [ $? -ne 0 ]; then
+      echo "Failed to install extension: $extension: $output"
+    fi
+  done
+  
+  if [ "${AUTO_INSTALL_EXTENSIONS}" = true ]; then
+    if ! command -v jq > /dev/null; then
+      echo "jq is required to install extensions from a workspace file."
+    else
+      WORKSPACE_DIR="$HOME"
+      if [ -n "${FOLDER}" ]; then
+        WORKSPACE_DIR="${FOLDER}"
+      fi
+  
+      if [ -f "$WORKSPACE_DIR/.vscode/extensions.json" ]; then
+        printf "🧩 Installing extensions from %s/.vscode/extensions.json...\n" "$WORKSPACE_DIR"
+        # Use sed to remove single-line comments before parsing with jq
+        extensions=$(sed 's|//.*||g' "$WORKSPACE_DIR"/.vscode/extensions.json | jq -r '.recommendations[]')
+        for extension in $extensions; do
+          $VSCODE_WEB "$EXTENSION_ARG" --install-extension "$extension" --force
+        done
+      fi
+    fi
+  fi
+}
 
 run_vscode_web
+install_extension

--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -61,11 +61,11 @@ esac
 if [ -n "${COMMIT_ID}" ]; then
   HASH="${COMMIT_ID}"
 else
-  HASH=$(curl -fsSL https://update.code.visualstudio.com/api/commits/stable/server-linux-${ARCH}-web | cut -d '"' -f 2)
+  HASH=$(curl -fsSL https://update.code.visualstudio.com/api/commits/stable/server-linux-$ARCH-web | cut -d '"' -f 2)
 fi
-printf "$${BOLD}VS Code Web commit id version ${HASH}.\n"
+printf "$${BOLD}VS Code Web commit id version $HASH.\n"
 
-output=$(curl -fsSL "https://vscode.download.prss.microsoft.com/dbazure/download/stable/${HASH}/vscode_cli_alpine_${ARCH}_cli.tar.gz" | tar -xz -C "${INSTALL_PREFIX}")
+output=$(curl -fsSL "https://vscode.download.prss.microsoft.com/dbazure/download/stable/$HASH/vscode_cli_alpine_"$ARCH"_cli.tar.gz" | tar -xz -C "${INSTALL_PREFIX}")
 
 if [ $? -ne 0 ]; then
   echo "Failed to install Microsoft Visual Studio Code Server: $output"
@@ -73,10 +73,10 @@ if [ $? -ne 0 ]; then
 fi
 printf "$${BOLD}VS Code Web has been installed.\n"
 
-VSCODE_WEB=~/.vscode/cli/serve-web/${HASH}/bin/code-server
+VSCODE_WEB=~/.vscode/cli/serve-web/$HASH/bin/code-server
 install_extension() {
   # code serve-web auto download code-server by health check trigger.
-  echo "Download code-server to ${VSCODE_WEB}."
+  echo "Download code-server to $VSCODE_WEB."
   
   while true; do
     if [ -f "$VSCODE_WEB" ]; then

--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -2,7 +2,6 @@
 
 BOLD='\033[0;1m'
 EXTENSIONS=("${EXTENSIONS}")
-VSCODE_WEB="${INSTALL_PREFIX}/bin/code-server"
 VSCODE_CLI="${INSTALL_PREFIX}/code"
 
 # Set extension directory
@@ -20,8 +19,7 @@ fi
 run_vscode_web() {
   echo "👷 Running $VSCODE_CLI serve-web $EXTENSION_ARG $SERVER_BASE_PATH_ARG --port ${PORT} --host 127.0.0.1 --accept-server-license-terms --without-connection-token in the background..."
   echo "Check logs at ${LOG_PATH}!"
-  # Todo: Add EXTENSION_ARG and SERVER_BASE_PATH_ARG
-  "$VSCODE_CLI" serve-web --port "${PORT}" --host 127.0.0.1 --accept-server-license-terms --without-connection-token > "${LOG_PATH}" 2>&1 &
+  "$VSCODE_CLI" serve-web ${EXTENSION_ARG} ${SERVER_BASE_PATH_ARG} --port "${PORT}" --host 127.0.0.1 --accept-server-license-terms --without-connection-token > "${LOG_PATH}" 2>&1 &
 }
 
 # Check if the settings file exists...
@@ -65,12 +63,11 @@ esac
 if [ -n "${COMMIT_ID}" ]; then
   HASH="${COMMIT_ID}"
 else
-  HASH=$(curl -fsSL https://update.code.visualstudio.com/api/commits/stable/server-linux-$ARCH-web | cut -d '"' -f 2)
+  HASH=$(curl -fsSL https://update.code.visualstudio.com/api/commits/stable/server-linux-${ARCH}-web | cut -d '"' -f 2)
 fi
-printf "$${BOLD}VS Code Web commit id version $HASH.\n"
+printf "$${BOLD}VS Code Web commit id version ${HASH}.\n"
 
-# Todo: Support download for other OS
-output=$(curl -fsSL "https://vscode.download.prss.microsoft.com/dbazure/download/stable/$HASH/vscode_cli_alpine_x64_cli.tar.gz" | tar -xz -C "${INSTALL_PREFIX}")
+output=$(curl -fsSL "https://vscode.download.prss.microsoft.com/dbazure/download/stable/${HASH}/vscode_cli_alpine_${ARCH}_cli.tar.gz" | tar -xz -C "${INSTALL_PREFIX}")
 
 if [ $? -ne 0 ]; then
   echo "Failed to install Microsoft Visual Studio Code Server: $output"
@@ -78,10 +75,10 @@ if [ $? -ne 0 ]; then
 fi
 printf "$${BOLD}VS Code Web has been installed.\n"
 
-VSCODE_WEB=~/.vscode/cli/serve-web/$HASH/bin/code-server
+VSCODE_WEB=~/.vscode/cli/serve-web/${HASH}/bin/code-server
 install_extension() {
   # code serve-web auto download code-server by health check trigger.
-  echo "Download code-server to $VSCODE_WEB."
+  echo "Download code-server to ${VSCODE_WEB}."
   
   while true; do
     if [ -f "$VSCODE_WEB" ]; then

--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -4,21 +4,22 @@ BOLD='\033[0;1m'
 EXTENSIONS=("${EXTENSIONS}")
 VSCODE_CLI="${INSTALL_PREFIX}/code"
 
-ARGS=()
 # Set extension directory
+EXTENSION_ARG=""
 if [ -n "${EXTENSIONS_DIR}" ]; then
-  ARGS+=("--extensions-dir=${EXTENSIONS_DIR}")
+  EXTENSION_ARG="--extensions-dir=${EXTENSIONS_DIR}"
 fi
 
 # Set extension directory
+SERVER_BASE_PATH_ARG=""
 if [ -n "${SERVER_BASE_PATH}" ]; then
-  ARGS+=("--server-base-path=${SERVER_BASE_PATH}")
+  SERVER_BASE_PATH_ARG="--server-base-path=${SERVER_BASE_PATH}"
 fi
 
 run_vscode_web() {
   echo "👷 Running $VSCODE_CLI serve-web $EXTENSION_ARG $SERVER_BASE_PATH_ARG --port ${PORT} --host 127.0.0.1 --accept-server-license-terms --without-connection-token in the background..."
   echo "Check logs at ${LOG_PATH}!"
-  "$VSCODE_CLI" serve-web "${ARGS[@]}" --port "${PORT}" --host 127.0.0.1 --accept-server-license-terms --without-connection-token > "${LOG_PATH}" 2>&1 &
+  "$VSCODE_CLI" serve-web ${EXTENSION_ARG:+$EXTENSION_ARG} ${SERVER_BASE_PATH_ARG:+$SERVER_BASE_PATH_ARG} --port "${PORT}" --host 127.0.0.1 --accept-server-license-terms --without-connection-token > "${LOG_PATH}" 2>&1 &
 }
 
 # Check if the settings file exists...

--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -78,7 +78,7 @@ if [ $? -ne 0 ]; then
 fi
 printf "$${BOLD}VS Code Web has been installed.\n"
 
-VSCODE_WEB="~/.vscode/cli/serve-web/$HASH/bin/code-server"
+VSCODE_WEB=~/.vscode/cli/serve-web/$HASH/bin/code-server
 install_extension() {
   echo "Wait for $VSCODE_WEB."
   

--- a/vscode-web/run.sh
+++ b/vscode-web/run.sh
@@ -80,11 +80,14 @@ printf "$${BOLD}VS Code Web has been installed.\n"
 
 VSCODE_WEB="~/.vscode/cli/serve-web/$HASH/bin/code-server"
 install_extension() {
+  echo "Wait for $VSCODE_WEB."
+  
   while true; do
     if [ -f "$VSCODE_WEB" ]; then
         echo "$VSCODE_WEB exists."
         break
     fi
+    echo "Wait for $VSCODE_WEB."
     sleep 5
   done
   


### PR DESCRIPTION
Hi,
The current VSCode Web module directly uses `code-server` to start a VSCode Web instance.
However, I noticed that the current VSCode Web only stores user credentials (e.g., GitHub authentication) in in-memory storage.

After investigating the VSCode source code, I discovered that VSCode Web requires a key from the `/mint-key` endpoint.
In Coder's `code-server`, the `/mint-key` endpoint is implemented.
However, in the official VSCode version, the `/mint-key` functionality is only available in the VSCode CLI (`code` binary).

To enable credential persistence, we need to use `code serve-web` to start a VSCode Web instance instead of the current `code-server serve-local`.

In this PR, I updated the process to use `code serve-web` to start a VSCode Web instance.
Most of the features from the old `code-server` are supported, except for the following two:

- `OFFLINE`
- `USE_CACHE`

I did not remove these variables from the `.tf` files to maintain compatibility.