### PR TITLE
feat(code-server): make `open_in` configurable

### DIFF
--- a/code-server/README.md
+++ b/code-server/README.md
@@ -15,7 +15,7 @@ Automatically install [code-server](https://github.com/coder/code-server) in a w
 module "code-server" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/modules/code-server/coder"
-  version  = "1.0.31"
+  version  = "1.1.0"
   agent_id = coder_agent.example.id
 }
 ```
@@ -30,7 +30,7 @@ module "code-server" {
 module "code-server" {
   count           = data.coder_workspace.me.start_count
   source          = "registry.coder.com/modules/code-server/coder"
-  version         = "1.0.31"
+  version         = "1.1.0"
   agent_id        = coder_agent.example.id
   install_version = "4.8.3"
 }
@@ -44,7 +44,7 @@ Install the Dracula theme from [OpenVSX](https://open-vsx.org/):
 module "code-server" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/modules/code-server/coder"
-  version  = "1.0.31"
+  version  = "1.1.0"
   agent_id = coder_agent.example.id
   extensions = [
     "dracula-theme.theme-dracula"
@@ -62,7 +62,7 @@ Configure VS Code's [settings.json](https://code.visualstudio.com/docs/getstarte
 module "code-server" {
   count      = data.coder_workspace.me.start_count
   source     = "registry.coder.com/modules/code-server/coder"
-  version    = "1.0.31"
+  version    = "1.1.0"
   agent_id   = coder_agent.example.id
   extensions = ["dracula-theme.theme-dracula"]
   settings = {
@@ -79,7 +79,7 @@ Just run code-server in the background, don't fetch it from GitHub:
 module "code-server" {
   count      = data.coder_workspace.me.start_count
   source     = "registry.coder.com/modules/code-server/coder"
-  version    = "1.0.31"
+  version    = "1.1.0"
   agent_id   = coder_agent.example.id
   extensions = ["dracula-theme.theme-dracula", "ms-azuretools.vscode-docker"]
 }
@@ -95,7 +95,7 @@ Run an existing copy of code-server if found, otherwise download from GitHub:
 module "code-server" {
   count      = data.coder_workspace.me.start_count
   source     = "registry.coder.com/modules/code-server/coder"
-  version    = "1.0.31"
+  version    = "1.1.0"
   agent_id   = coder_agent.example.id
   use_cached = true
   extensions = ["dracula-theme.theme-dracula", "ms-azuretools.vscode-docker"]
@@ -108,7 +108,7 @@ Just run code-server in the background, don't fetch it from GitHub:
 module "code-server" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/modules/code-server/coder"
-  version  = "1.0.31"
+  version  = "1.1.0"
   agent_id = coder_agent.example.id
   offline  = true
 }

--- a/code-server/main.tf
+++ b/code-server/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.17"
+      version = ">= 2.1"
     }
   }
 }
@@ -122,6 +122,16 @@ variable "subdomain" {
   default     = false
 }
 
+variable "open_in" {
+  type        = string
+  description = <<-EOT
+    Determines where the app will be opened. Valid values are `"tab"` and `"slim-window" (default)`.
+    `"tab"` opens in a new tab in the same browser window.
+    `"slim-window"` opens a new browser window without navigation controls.
+  EOT
+  default     = "slim-window"
+}
+
 resource "coder_script" "code-server" {
   agent_id     = var.agent_id
   display_name = "code-server"
@@ -166,6 +176,7 @@ resource "coder_app" "code-server" {
   subdomain    = var.subdomain
   share        = var.share
   order        = var.order
+  open_in      = var.open_in
 
   healthcheck {
     url       = "http://localhost:${var.port}/healthz"

--- a/code-server/main.tf
+++ b/code-server/main.tf
@@ -130,6 +130,10 @@ variable "open_in" {
     `"slim-window"` opens a new browser window without navigation controls.
   EOT
   default     = "slim-window"
+  validation {
+    condition     = contains(["tab", "slim-window"], var.open_in)
+    error_message = "The 'open_in' variable must be one of: 'tab', 'slim-window'."
+  }
 }
 
 resource "coder_script" "code-server" {


### PR DESCRIPTION
`open_in` option for Coder App was introduced in `2.1.0`. It would be nice to expose it in `code-server` so that we can configure `code-server` to open in new tab instead of new window. 