### PR TITLE
fix(devcontainers-cli): add PNPM_HOME for pnpm package manager

### DIFF
--- a/devcontainers-cli/main.test.ts
+++ b/devcontainers-cli/main.test.ts
@@ -30,7 +30,7 @@ const executeScriptInContainerWithPackageManager = async (
     await execContainer(id, [
       shell,
       "-c",
-      "apk add nodejs npm && npm install -g pnpm",
+      `wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -`,
     ]);
   } else if (packageManager === "yarn") {
     await execContainer(id, [
@@ -86,7 +86,7 @@ describe("devcontainers-cli", async () => {
     expect(output.stdout[output.stdout.length - 1]).toEqual(
       "🥳 @devcontainers/cli has been installed into /usr/local/bin/devcontainer!",
     );
-  });
+  }, 15000);
 
   it("installs devcontainers-cli with yarn", async () => {
     const state = await runTerraformApply(import.meta.dir, {

--- a/devcontainers-cli/run.sh
+++ b/devcontainers-cli/run.sh
@@ -12,12 +12,12 @@ if ! command -v docker > /dev/null 2>&1; then
 fi
 
 # Determine the package manager to use: npm, pnpm, or yarn
-if command -v pnpm > /dev/null 2>&1; then
-  PACKAGE_MANAGER="pnpm"
-elif command -v yarn > /dev/null 2>&1; then
+if command -v yarn > /dev/null 2>&1; then
   PACKAGE_MANAGER="yarn"
 elif command -v npm > /dev/null 2>&1; then
   PACKAGE_MANAGER="npm"
+elif command -v pnpm > /dev/null 2>&1; then
+  PACKAGE_MANAGER="pnpm"
 else
   echo "ERROR: No supported package manager (npm, pnpm, yarn) is installed. Please install one first." 1>&2
   exit 1
@@ -26,8 +26,15 @@ fi
 echo "Installing @devcontainers/cli using $PACKAGE_MANAGER..."
 
 # Install @devcontainers/cli using the selected package manager
-if [ "$PACKAGE_MANAGER" = "npm" ] || [ "$PACKAGE_MANAGER" = "pnpm" ]; then
-  $PACKAGE_MANAGER install -g @devcontainers/cli \
+if [ "$PACKAGE_MANAGER" = "npm" ]; then
+    $PACKAGE_MANAGER install -g @devcontainers/cli \
+    && echo "🥳 @devcontainers/cli has been installed into $(which devcontainer)!"
+elif [ "$PACKAGE_MANAGER" = "pnpm" ]; then
+    # if PNPM_HOME is not set, set it to the bin directory of the script
+    if [ -z "$PNPM_HOME" ]; then
+        export PNPM_HOME="$CODER_SCRIPT_BIN_DIR"
+    fi
+    $PACKAGE_MANAGER add -g @devcontainers/cli \
     && echo "🥳 @devcontainers/cli has been installed into $(which devcontainer)!"
 elif [ "$PACKAGE_MANAGER" = "yarn" ]; then
   $PACKAGE_MANAGER global add @devcontainers/cli \


### PR DESCRIPTION
PNPM requires `$PNPM_HOME` to be set to install packages. 
This PR is a follow-up on the one creating @devcontainers-cli module - to ensure PNPM_HOME is set, based on values set by Coder.