### PR TITLE
fix(vault-jwt): store vault token for use in vault jwt module

### DIFF
--- a/vault-jwt/README.md
+++ b/vault-jwt/README.md
@@ -16,7 +16,7 @@ This module lets you authenticate with [Hashicorp Vault](https://www.vaultprojec
 module "vault" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/modules/vault-jwt/coder"
-  version        = "1.0.20"
+  version        = "1.0.21"
   agent_id       = coder_agent.example.id
   vault_addr     = "https://vault.example.com"
   vault_jwt_role = "coder" # The Vault role to use for authentication
@@ -43,7 +43,7 @@ curl -H "X-Vault-Token: ${VAULT_TOKEN}" -X GET "${VAULT_ADDR}/v1/coder/secrets/d
 module "vault" {
   count               = data.coder_workspace.me.start_count
   source              = "registry.coder.com/modules/vault-jwt/coder"
-  version             = "1.0.20"
+  version             = "1.0.21"
   agent_id            = coder_agent.example.id
   vault_addr          = "https://vault.example.com"
   vault_jwt_auth_path = "oidc"
@@ -59,7 +59,7 @@ data "coder_workspace_owner" "me" {}
 module "vault" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/modules/vault-jwt/coder"
-  version        = "1.0.20"
+  version        = "1.0.21"
   agent_id       = coder_agent.example.id
   vault_addr     = "https://vault.example.com"
   vault_jwt_role = data.coder_workspace_owner.me.groups[0]
@@ -72,7 +72,7 @@ module "vault" {
 module "vault" {
   count             = data.coder_workspace.me.start_count
   source            = "registry.coder.com/modules/vault-jwt/coder"
-  version           = "1.0.20"
+  version           = "1.0.21"
   agent_id          = coder_agent.example.id
   vault_addr        = "https://vault.example.com"
   vault_jwt_role    = "coder" # The Vault role to use for authentication

--- a/vault-jwt/run.sh
+++ b/vault-jwt/run.sh
@@ -107,6 +107,6 @@ rm -rf "$TMP"
 
 # Authenticate with Vault
 printf "🔑 Authenticating with Vault ...\n\n"
-echo "$${CODER_OIDC_ACCESS_TOKEN}" | vault write auth/"$${VAULT_JWT_AUTH_PATH}"/login role="$${VAULT_JWT_ROLE}" jwt=-
+echo "$${CODER_OIDC_ACCESS_TOKEN}" | vault write -field=token auth/"$${VAULT_JWT_AUTH_PATH}"/login role="$${VAULT_JWT_ROLE}" jwt=- | vault login -
 printf "🥳 Vault authentication complete!\n\n"
 printf "You can now use Vault CLI to access secrets.\n"


### PR DESCRIPTION

currently, the vault jwt module generates a vault token, but it doesnt actually store it for future vault commands to use.

even with the module configured, running `vault token lookup` fails, because the login command in the module just prints the token but doesnt keep it to be used by future calls to vault

added `-field=token` to the write command, which makes it print only the token itself to stdout, not the rest of the info about the token
then pipe that into `vault login -`, which reads from stdin, and does the process of actually storing the token for future use.

(compared to the other vault coder modules which both call `vault login`, but this one doesnt, but it should.)