### PR TITLE
ci: deploy dev registry on tag pushes

### DIFF
--- a/.github/workflows/deploy-registry.yaml
+++ b/.github/workflows/deploy-registry.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "release/*/v*" # Matches tags like release/module-name/v1.0.0
 
 jobs:
   deploy:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to enhance deployment flexibility by allowing it to trigger on specific tag patterns in addition to pushes to the `main` branch.

Workflow trigger update:

* [`.github/workflows/deploy-registry.yaml`](diffhunk://#diff-fbf55ed2cd70e3380da25686178b863d15e0dcd8b5c8f4115ea33fae51bbd883R7-R8): Added a `tags` condition under the `push` event to trigger the workflow for tags matching the pattern `release/*/v*` (e.g., `release/module-name/v1.0.0`).