### PR TITLE
fix(jupyterlab): fix path to jupyter-lab if already installed

### DIFF
--- a/jupyterlab/README.md
+++ b/jupyterlab/README.md
@@ -17,7 +17,7 @@ A module that adds JupyterLab in your Coder template.
 module "jupyterlab" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/modules/jupyterlab/coder"
-  version  = "1.0.30"
+  version  = "1.0.31"
   agent_id = coder_agent.example.id
 }
 ```

--- a/jupyterlab/run.sh
+++ b/jupyterlab/run.sh
@@ -34,21 +34,22 @@ if ! command -v jupyter-lab > /dev/null 2>&1; then
     uv)
       uv pip install -q jupyterlab \
         && printf "%s\n" "🥳 jupyterlab has been installed"
-      JUPYTERPATH="$HOME/.venv/bin/"
+      JUPYTER="$HOME/.venv/bin/jupyter-lab"
       ;;
     pipx)
       pipx install jupyterlab \
         && printf "%s\n" "🥳 jupyterlab has been installed"
-      JUPYTERPATH="$HOME/.local/bin"
+      JUPYTER="$HOME/.local/bin/jupyter-lab"
       ;;
   esac
 else
   printf "%s\n\n" "🥳 jupyterlab is already installed"
+  JUPYTER=$(command -v jupyter-lab)
 fi
 
 printf "👷 Starting jupyterlab in background..."
 printf "check logs at ${LOG_PATH}"
-$JUPYTERPATH/jupyter-lab --no-browser \
+$JUPYTER --no-browser \
   "$BASE_URL_FLAG" \
   --ServerApp.ip='*' \
   --ServerApp.port="${PORT}" \


### PR DESCRIPTION
If the `jupyter-lab` binary already exists in $PATH, as found by `command -v jupyter-lab`, then we skip installing using `pipx` or `uv`.

By skipping the install path, we leave `${JUPYTERPATH}` unset, which then leads to a broken module unless `jupyter-lab` just so happens to be installed at `/jupyter-lab`.

Fix this by calculating the full path to the binary, either from the install locations of `pipx`, `uv` or, in the case that it was preinstalled, from the preinstalled location.

I did not test this. I would have added a test but the current tests don't run because
they're too slow.