### PR TITLE
ci: add deploy to main trigger

### DIFF
--- a/.github/workflows/deploy-registry.yaml
+++ b/.github/workflows/deploy-registry.yaml
@@ -36,4 +36,8 @@ jobs:
       - name: Deploy to dev.registry.coder.com
         run: |
           gcloud builds triggers run 29818181-126d-4f8a-a937-f228b27d3d34 --branch dev
+
+      - name: Deploy to registry.coder.com
+        run: |
+          gcloud builds triggers run 106610ff-41fb-4bd0-90a2-7643583fb9c0 --branch main
   


### PR DESCRIPTION
This PR adds the trigger to auto deploy the prod registry alongside dev when we do a merge to main or tag a release.