### PR TITLE
fix(devcontainer-cli): install to `$CODER_SCRIPT_BIN_DIR` when using yarn

### DIFF
--- a/devcontainers-cli/README.md
+++ b/devcontainers-cli/README.md
@@ -16,7 +16,7 @@ The devcontainers-cli module provides an easy way to install [`@devcontainers/cl
 ```tf
 module "devcontainers-cli" {
   source   = "registry.coder.com/modules/devcontainers-cli/coder"
-  version  = "1.0.1"
+  version  = "1.0.2"
   agent_id = coder_agent.example.id
 }
 ```

--- a/devcontainers-cli/run.sh
+++ b/devcontainers-cli/run.sh
@@ -38,7 +38,7 @@ install() {
     fi
     pnpm add -g @devcontainers/cli
   elif [ "$PACKAGE_MANAGER" = "yarn" ]; then
-    yarn global add @devcontainers/cli
+    yarn global add @devcontainers/cli --prefix "$CODER_SCRIPT_BIN_DIR"
   fi
 }
 


### PR DESCRIPTION
When using `codercom/enterprise-node`, this will install the `devcontainer` cli into `/home/coder/.yarn/bin`, which is _not_ in `$PATH`. To work around this, we'll install it into `$CODER_SCRIPT_BIN_DIR`, like we do with `pnpm`.