### PR TITLE
feat(vault-token): make supplying a vault token optional

### DIFF
--- a/vault-token/main.test.ts
+++ b/vault-token/main.test.ts
@@ -7,6 +7,5 @@ describe("vault-token", async () => {
   testRequiredVariables(import.meta.dir, {
     agent_id: "foo",
     vault_addr: "foo",
-    vault_token: "foo",
   });
 });

--- a/vault-token/main.tf
+++ b/vault-token/main.tf
@@ -24,6 +24,7 @@ variable "vault_token" {
   type        = string
   description = "The Vault token to use for authentication."
   sensitive   = true
+  default     = null
 }
 
 variable "vault_cli_version" {
@@ -56,6 +57,7 @@ resource "coder_env" "vault_addr" {
 }
 
 resource "coder_env" "vault_token" {
+  count    = var.vault_token != null ? 1 : 0
   agent_id = var.agent_id
   name     = "VAULT_TOKEN"
   value    = var.vault_token


### PR DESCRIPTION
makes the vault token variable optional, 
meaning that template creators can use the vault token module just to install vault cli, without it configuring a token environment variable.
the template creator can then log into vault with their own script, 
or they can ask the user to manually run `vault login` command


potential future change: refactor the vault-jwt and the vault-github modules in this repo to call this module for installing vault, and their scripts only need to call the relevant login command, they dont need to download and install vault. makes maintaining easier if you have just one install script.